### PR TITLE
feat: VCP v3.2 / VEP-0004 SDK upgrade (Python + TypeScript + Rust)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the VCP SDK will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2026-04-06
+
+### Added
+- **PDP Enforcement Module** (`vcp/enforcement.py`) — Standalone policy enforcement for VCP bundles without requiring a full safety stack. Includes `PDPPlugin` interface, `PDPEnforcer` orchestrator, and three built-in plugins: `RefusalBoundaryPlugin`, `AdherenceLevelPlugin`, `BundleExpiryPlugin`.
+- **Purge Handler Registration** — `AuditLogger.register_purge_handler()` lets external sinks (Redis, database) register GDPR purge logic. Warns if `log_callback` is set without a handler.
+
+### Fixed
+- **GDPR Purge Persistence Gap** — `purge_by_session()` now scrubs exported JSON files (not just in-memory entries), with thread-safe file rewriting and tombstone receipts that include file-level evidence.
+- **`datetime.utcnow()` Deprecation** — All remaining instances replaced with `datetime.now(timezone.utc)` across source and test files.
+- **Thread Safety** — `export_json()` path tracking and `_purge_exported_files()` now run inside `self._lock`, closing TOCTOU race conditions.
+
 ## [4.0.0] - 2026-03-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 - **VCP Specification v1.1** -- R-line (Line 8) for real-time personal state in CSM-1 tokens
 - **Rust SDK** (`vcp-core`, `vcp-wasm`, `vcp-cli`) -- High-performance parsing with `no_std` support and WASM bindings
-- **TypeScript/WebMCP SDK** (`@vcp/webmcp`) -- Browser-side VCP tool registration via `navigator.modelContext` (Chrome 145+)
+- **TypeScript/WebMCP SDK** (`@creed-space/vcp-sdk`) -- Browser-side VCP tool registration via `navigator.modelContext` (Chrome 145+)
 - MCP-B polyfill for non-Chrome browsers
 - Five WebMCP tools: `vcp_chat`, `vcp_build_token`, `vcp_parse_token`, `vcp_transmission_summary`, `vcp_list_personas`
 - JSON Schema definitions for all protocol layers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the VCP SDK will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.0] - 2026-04-22
+
+### Added
+- **VCP v3.2 / VEP-0004 adaptation layer** — `vcp.adaptation.context` (Python), `src/extensions/context.ts` (TypeScript), `vcp_core::situational` + `vcp_core::context` (Rust) now implement the full 18-dimension v3.2 context model:
+  - 13 situational dimensions (positions 1-13): time, space, company, culture, occasion, environment, agency, constraints, system_context, **embodiment** (VEP-0004, pos 10), **proximity** (VEP-0004, pos 11), **relationship** (VEP-0004, pos 12), **formality** (VEP-0004, pos 13).
+  - 5 personal-state dimensions on the R-line: cognitive_state, emotional_tone, energy_level, perceived_urgency, body_signals — each an optional `{value, intensity 1-5}`.
+  - Wire-format band separator `‖` (U+2016 DOUBLE VERTICAL LINE) between situational and personal halves.
+  - RELATIONSHIP is free-form: its value is a compound `{tie}:{function}` string (e.g. `colleague:professional`), not a closed emoji vocabulary.
+- **Conformance classification** — `conformance_level()` method on `VCPContext` / `FullContext` (Python + TypeScript + Rust) returns `VCP-Minimal` (core 9 only), `VCP-Standard` (core + R-line), or `VCP-Extended` (any VEP-0004 dim).
+- **VEP-0004 conformance fixtures** — `conformance/adaptation/context_encoding_extended.json` with 12 test vectors covering each VEP-0004 dimension in isolation, the canonical 18-dim example, VS16 parser-compatibility (↔️ qualified vs bare), and the Extended-over-Standard precedence rule.
+- **JSON Schema v3.2** — `schemas/vcp-adaptation-context.schema.json` upgraded from v2 to v3.2 with nested `parsed.situational` / `parsed.personal` shape, `conformance_level` enum field, and per-dimension value definitions.
+
+### Changed
+- **CULTURE values** are now communication styles per CSM-1 (high_context, low_context, formal, casual, mixed), not nationalities. The nationality vocabulary was never in spec and is rejected by the v3.2 encoders.
+- Python `VCPContext` refactored from a plain `@dataclass` to a class with `__slots__` and backwards-compatible `dimensions=` constructor kwarg (aliases `situational=`).
+- Python exports `SituationalDimension` and `PersonalStateDimension` from `vcp.adaptation`; `Dimension` remains as a backwards-compat alias for `SituationalDimension`.
+- Rust `FullContext::situational` is now a 13-dimension `SituationalContext`; the enum gains `Embodiment`, `Proximity`, `Relationship`, `Formality` variants and a `position()` accessor. `ConformanceLevel` is re-exported at the crate root.
+
+### Removed
+- The deprecated VCP v3.0 **STATE** dimension (removed in v3.1; SYSTEM_CONTEXT occupies position 9 and the prior STATE enum value is no longer exposed).
+
 ## [4.1.0] - 2026-04-06
 
 ### Added
@@ -89,8 +110,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Dependabot configuration for all package ecosystems
 - Comprehensive README with architecture diagrams, quick-start guides, and full documentation index
 
+[4.2.0]: https://github.com/Creed-Space/VCP-SDK/compare/v4.1.0...v4.2.0
+[4.1.0]: https://github.com/Creed-Space/VCP-SDK/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/Creed-Space/VCP-SDK/compare/v3.1.0...v4.0.0
-[Unreleased]: https://github.com/Creed-Space/VCP-SDK/compare/v4.0.0...HEAD
+[Unreleased]: https://github.com/Creed-Space/VCP-SDK/compare/v4.2.0...HEAD
 [3.1.0]: https://github.com/Creed-Space/VCP-SDK/compare/v1.1.0...v3.1.0
 [1.1.0]: https://github.com/Creed-Space/VCP-SDK/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/Creed-Space/VCP-SDK/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # VCP SDK — Official SDK for the Value Context Protocol
 
-**Multi-language SDK for VCP v3.1 — parse tokens, encode context, negotiate capabilities across all six protocol layers (I-T-S-A-M-E).**
+**Multi-language SDK for VCP v3.2 (incl. VEP-0004) — parse tokens, encode context, negotiate capabilities across all six protocol layers (I-T-S-A-M-E).**
 
 [![CI](https://github.com/Creed-Space/VCP-SDK/actions/workflows/ci.yml/badge.svg)](https://github.com/Creed-Space/VCP-SDK/actions/workflows/ci.yml)
 [![Python SDK](https://img.shields.io/badge/python-4.0.0-3776AB?style=flat-square&logo=python&logoColor=white)](./python/)
@@ -20,17 +20,17 @@
 
 The **Value-Context Protocol (VCP)** is an open specification for transporting constitutional values, behavioral rules, and personal context to AI systems. The VCP SDK provides production-ready implementations in Python, TypeScript, and Rust with full cross-language parity.
 
-VCP v3.1 defines six protocol layers (I-T-S-A-M-E) alongside five opt-in extensions and a capability negotiation handshake, enabling rich context exchange between humans and AI.
+VCP v3.2 defines six protocol layers (I-T-S-A-M-E) alongside five opt-in extensions and a capability negotiation handshake, enabling rich context exchange between humans and AI. The adaptation layer (VCP/A) encodes situational context in 13 dimensions (9 core + 4 VEP-0004) plus 5 personal-state dimensions on the R-line.
 
 ---
 
-## Features (v3.1)
+## Features (v3.2)
 
 ### The Six Layers (I-T-S-A-M-E)
 - **VCP/I (Identity)** — Token parsing, naming, namespace management
 - **VCP/T (Transport)** — Signed bundles with Ed25519 signatures and SHA-256 content hashes
 - **VCP/S (Semantics)** — CSM-1 grammar, personas, composition rules
-- **VCP/A (Adaptation)** — Context encoding, state tracking, deterministic hooks
+- **VCP/A (Adaptation)** — Context encoding (13 situational + 5 personal-state dimensions, incl. VEP-0004: embodiment, proximity, relationship, formality), state tracking, deterministic hooks. Three conformance tiers: **VCP-Minimal** (core 9), **VCP-Standard** (core + R-line), **VCP-Extended** (any VEP-0004 dim).
 - **VCP/M (Messaging)** — Inter-agent message types: context_share, constitution_announce, constraint_propagate, escalation with severity levels
 - **VCP/E (Economic Governance)** — Fiduciary constraints, authorization gaps (capability, accountability, compatibility), transaction governance
 
@@ -189,11 +189,11 @@ cd rust && cargo test conformance
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-### v3.1 Extensions (VCP-X-*)
+### v3.2 Extensions (VCP-X-*)
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│                      VCP v3.1 Extensions (VCP-X-*)                  │
+│                      VCP v3.2 Extensions (VCP-X-*)                  │
 ├──────────────┬──────────────┬──────────────────┬────────────────────┤
 │ Personal     │ Relational   │ Constitutional   │ Session   │ Intent │
 │ State        │ Context      │ Consensus        │ Handoff   │        │

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 **Multi-language SDK for VCP v3.2 (incl. VEP-0004) — parse tokens, encode context, negotiate capabilities across all six protocol layers (I-T-S-A-M-E).**
 
 [![CI](https://github.com/Creed-Space/VCP-SDK/actions/workflows/ci.yml/badge.svg)](https://github.com/Creed-Space/VCP-SDK/actions/workflows/ci.yml)
-[![Python SDK](https://img.shields.io/badge/python-4.0.0-3776AB?style=flat-square&logo=python&logoColor=white)](./python/)
-[![TypeScript SDK](https://img.shields.io/badge/typescript-4.0.0-3178C6?style=flat-square&logo=typescript&logoColor=white)](./webmcp/)
-[![Rust SDK](https://img.shields.io/badge/rust-4.0.0-DEA584?style=flat-square&logo=rust&logoColor=white)](./rust/)
+[![Python SDK](https://img.shields.io/badge/python-4.2.0-3776AB?style=flat-square&logo=python&logoColor=white)](./python/)
+[![TypeScript SDK](https://img.shields.io/badge/typescript-4.2.0-3178C6?style=flat-square&logo=typescript&logoColor=white)](./webmcp/)
+[![Rust SDK](https://img.shields.io/badge/rust-4.2.0-DEA584?style=flat-square&logo=rust&logoColor=white)](./rust/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green?style=flat-square)](./LICENSE)
 
 [Spec](https://github.com/Creed-Space/VCP-Spec) · [Inspector](https://inspector.valuecontextprotocol.org/) · [Website](https://valuecontextprotocol.org/)

--- a/conformance/adaptation/context_encoding_extended.json
+++ b/conformance/adaptation/context_encoding_extended.json
@@ -1,0 +1,240 @@
+{
+  "suite": "adaptation/context_encoding_extended",
+  "version": "3.2.0",
+  "description": "VCP v3.2 conformance fixtures for the VEP-0004 situational dimensions (positions 10-13): EMBODIMENT, PROXIMITY, RELATIONSHIP, FORMALITY. These vectors target the VCP-Extended conformance tier. Personal-state (R-line) field names are 'value' + 'intensity' (1-5). The band separator between situational and personal wire halves is U+2016 (\u2016 DOUBLE VERTICAL LINE). Situational dims are joined with '|'. RELATIONSHIP is free-form: its value is a compound '{tie}:{function}' string rather than an emoji from a fixed vocabulary.",
+  "conformance_level": "VCP-Extended",
+  "vectors": [
+    {
+      "id": "vep-001",
+      "description": "EMBODIMENT alone (standing person + manipulating hand): VEP-0004 minimum, no core/personal",
+      "input": {
+        "situational": {
+          "embodiment": ["\u270B"]
+        },
+        "personal": {}
+      },
+      "expected": {
+        "wire": "\ud83e\uddcd\u270b",
+        "wire_contains": "\ud83e\uddcd",
+        "conformance_level": "VCP-Extended",
+        "has_situational": true,
+        "has_vep_0004": true,
+        "has_personal": false,
+        "note": "EMBODIMENT symbol 🧍 (U+1F9CD) + manipulating hand ✋ (U+270B). One dim only → no pipe."
+      }
+    },
+    {
+      "id": "vep-002",
+      "description": "PROXIMITY alone (left-right arrow + pinching hand): VS16 symbol handling",
+      "input": {
+        "situational": {
+          "proximity": ["\ud83e\udd0f"]
+        },
+        "personal": {}
+      },
+      "expected": {
+        "wire": "\u2194\ufe0f\ud83e\udd0f",
+        "wire_contains": "\u2194\ufe0f",
+        "conformance_level": "VCP-Extended",
+        "has_vep_0004": true,
+        "note": "PROXIMITY symbol ↔️ is U+2194 + U+FE0F (VS16). Value 🤏 (U+1F90F) = intimate distance. Parsers MUST accept both the VS16-qualified and bare (U+2194 only) forms."
+      }
+    },
+    {
+      "id": "vep-003",
+      "description": "RELATIONSHIP free-form compound: colleague:professional",
+      "input": {
+        "situational": {
+          "relationship": ["colleague:professional"]
+        },
+        "personal": {}
+      },
+      "expected": {
+        "wire": "\ud83e\udea2colleague:professional",
+        "wire_contains": "\ud83e\udea2colleague:professional",
+        "conformance_level": "VCP-Extended",
+        "has_vep_0004": true,
+        "roundtrip_preserves_relationship_compound": true,
+        "note": "RELATIONSHIP 🪢 (U+1FAA2) carries free-form '{tie}:{function}' strings, NOT emoji. The internal colon is part of the value and MUST NOT be interpreted as an intensity separator (intensity is R-line only)."
+      }
+    },
+    {
+      "id": "vep-004",
+      "description": "RELATIONSHIP alternates: stranger:service, family:caregiving, friend:social",
+      "input": {
+        "situational": {
+          "relationship": ["stranger:service"]
+        },
+        "personal": {}
+      },
+      "expected": {
+        "wire": "\ud83e\udea2stranger:service",
+        "roundtrip_preserves_relationship_compound": true,
+        "note": "Any non-empty '{tie}:{function}' pair is valid; there is no closed vocabulary for RELATIONSHIP."
+      }
+    },
+    {
+      "id": "vep-005",
+      "description": "FORMALITY alone (top hat + briefcase): professional register",
+      "input": {
+        "situational": {
+          "formality": ["\ud83d\udcbc"]
+        },
+        "personal": {}
+      },
+      "expected": {
+        "wire": "\ud83c\udfa9\ud83d\udcbc",
+        "wire_contains": "\ud83c\udfa9",
+        "conformance_level": "VCP-Extended",
+        "has_vep_0004": true,
+        "note": "FORMALITY symbol 🎩 (U+1F3A9) + professional value 💼 (U+1F4BC)."
+      }
+    },
+    {
+      "id": "vep-006",
+      "description": "All four VEP-0004 dims in canonical position order (10, 11, 12, 13)",
+      "input": {
+        "situational": {
+          "embodiment": ["\u270B"],
+          "proximity": ["\ud83e\udd0f"],
+          "relationship": ["colleague:professional"],
+          "formality": ["\ud83d\udcbc"]
+        },
+        "personal": {}
+      },
+      "expected": {
+        "wire": "\ud83e\uddcd\u270b|\u2194\ufe0f\ud83e\udd0f|\ud83e\udea2colleague:professional|\ud83c\udfa9\ud83d\udcbc",
+        "conformance_level": "VCP-Extended",
+        "dimension_order": ["embodiment", "proximity", "relationship", "formality"],
+        "note": "VEP-0004 dims encode in strict position order. EMBODIMENT=10, PROXIMITY=11, RELATIONSHIP=12, FORMALITY=13."
+      }
+    },
+    {
+      "id": "vep-007",
+      "description": "Core situational + all VEP-0004 dims, no personal (Extended without R-line)",
+      "input": {
+        "situational": {
+          "time": ["\ud83c\udf05"],
+          "space": ["\ud83c\udfe2"],
+          "company": ["\ud83d\udc54"],
+          "occasion": ["\ud83d\udcbc"],
+          "embodiment": ["\u270B"],
+          "proximity": ["\ud83e\udd0f"],
+          "relationship": ["colleague:professional"],
+          "formality": ["\ud83d\udcbc"]
+        },
+        "personal": {}
+      },
+      "expected": {
+        "wire": "\u23f0\ud83c\udf05|\ud83d\udccd\ud83c\udfe2|\ud83d\udc65\ud83d\udc54|\ud83c\udfad\ud83d\udcbc|\ud83e\uddcd\u270b|\u2194\ufe0f\ud83e\udd0f|\ud83e\udea2colleague:professional|\ud83c\udfa9\ud83d\udcbc",
+        "conformance_level": "VCP-Extended",
+        "has_personal": false,
+        "has_vep_0004": true,
+        "separator_u2016_present": false,
+        "note": "Extended is triggered by ANY VEP-0004 dim regardless of personal presence. Here the \u2016 band separator is absent because personal is empty."
+      }
+    },
+    {
+      "id": "vep-008",
+      "description": "Canonical VCP v3.2 18-dim example (spec §2 + §A.3): full Extended with R-line",
+      "input": {
+        "situational": {
+          "time": ["\ud83c\udf05"],
+          "space": ["\ud83c\udfe2"],
+          "company": ["\ud83d\udc54"],
+          "occasion": ["\ud83d\udcbc"],
+          "embodiment": ["\u270B"],
+          "proximity": ["\ud83e\udd0f"],
+          "relationship": ["colleague:professional"],
+          "formality": ["\ud83d\udcbc"]
+        },
+        "personal": {
+          "cognitive_state": { "value": "focused", "intensity": 4 },
+          "emotional_tone": { "value": "calm", "intensity": 5 },
+          "energy_level": { "value": "rested", "intensity": 4 },
+          "perceived_urgency": { "value": "unhurried", "intensity": 2 },
+          "body_signals": { "value": "neutral", "intensity": 1 }
+        }
+      },
+      "expected": {
+        "wire": "\u23f0\ud83c\udf05|\ud83d\udccd\ud83c\udfe2|\ud83d\udc65\ud83d\udc54|\ud83c\udfad\ud83d\udcbc|\ud83e\uddcd\u270b|\u2194\ufe0f\ud83e\udd0f|\ud83e\udea2colleague:professional|\ud83c\udfa9\ud83d\udcbc\u2016\ud83e\udde0focused:4|\ud83d\udcadcalm:5|\ud83d\udd0brested:4|\u26a1unhurried:2|\ud83e\ude7aneutral:1",
+        "conformance_level": "VCP-Extended",
+        "has_personal": true,
+        "has_vep_0004": true,
+        "separator_u2016_present": true,
+        "note": "Canonical v3.2 worst-case fixture. 8 situational (4 core + 4 VEP-0004) joined by '|', then \u2016 (U+2016 DOUBLE VERTICAL LINE) band separator, then 5 personal-state dims with intensity suffix. Matches the example in schemas/vcp-adaptation-context.schema.json."
+      }
+    },
+    {
+      "id": "vep-009",
+      "description": "RELATIONSHIP containing an emoji in the tie slot",
+      "input": {
+        "situational": {
+          "relationship": ["parent:caregiving"]
+        },
+        "personal": {}
+      },
+      "expected": {
+        "wire": "\ud83e\udea2parent:caregiving",
+        "roundtrip_preserves_relationship_compound": true,
+        "note": "RELATIONSHIP values are arbitrary strings. Implementations MUST NOT validate against a closed vocabulary for the tie or function slot."
+      }
+    },
+    {
+      "id": "vep-010",
+      "description": "Single VEP-0004 dim (FORMALITY) with personal R-line: Extended (not Standard)",
+      "input": {
+        "situational": {
+          "formality": ["\ud83c\udf93"]
+        },
+        "personal": {
+          "cognitive_state": { "value": "focused", "intensity": 3 }
+        }
+      },
+      "expected": {
+        "wire_contains": "\ud83c\udfa9\ud83c\udf93",
+        "wire_contains_separator_u2016": true,
+        "conformance_level": "VCP-Extended",
+        "classification_precedence": "extended_over_standard",
+        "note": "Extended precedence rule: the presence of any VEP-0004 dim makes the context Extended, even if personal-state dims are also present (which would otherwise make it Standard). 🎓 (U+1F393) = academic register."
+      }
+    },
+    {
+      "id": "vep-011",
+      "description": "PROXIMITY parse compatibility: VS16-qualified vs bare",
+      "input": {
+        "situational": {
+          "proximity": ["\ud83c\udf10"]
+        },
+        "personal": {},
+        "alternate_wire_forms": [
+          "\u2194\ufe0f\ud83c\udf10",
+          "\u2194\ud83c\udf10"
+        ]
+      },
+      "expected": {
+        "wire": "\u2194\ufe0f\ud83c\udf10",
+        "decoder_must_accept_both_forms": true,
+        "note": "Canonical encoder emits the VS16-qualified form ↔️ (U+2194 U+FE0F). Parsers MUST also accept the bare form (U+2194 only). 🌐 (U+1F310) = remote/global distance."
+      }
+    },
+    {
+      "id": "vep-012",
+      "description": "EMBODIMENT emergency signal 🛑 (stop): risk-aware encoding",
+      "input": {
+        "situational": {
+          "embodiment": ["\ud83d\uded1"]
+        },
+        "personal": {}
+      },
+      "expected": {
+        "wire": "\ud83e\uddcd\ud83d\uded1",
+        "conformance_level": "VCP-Extended",
+        "metadata": {
+          "has_emergency": true
+        },
+        "note": "🛑 (U+1F6D1) on EMBODIMENT signals an emergency halt (see schema metadata.has_emergency). Implementations MAY elevate risk_level accordingly."
+      }
+    }
+  ]
+}

--- a/docs/VCP_NEWCOMER_GUIDE.md
+++ b/docs/VCP_NEWCOMER_GUIDE.md
@@ -40,7 +40,7 @@ The **Value-Context Protocol (VCP)** is a unified protocol stack for expressing,
 ├─────────────────────────────────────────────────────────────────┤
 │  Layer 1: VCP-IDENTITY (VCP/I)                                  │
 │  "What it's Called" - Token naming, namespaces, registry        │
-│  Maps to: UVC (Universal Values Corpus)                         │
+│  Maps to: UVC (Universal Value Coding)                         │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -48,7 +48,7 @@ The **Value-Context Protocol (VCP)** is a unified protocol stack for expressing,
 
 | Research Concept | VCP Layer | Purpose |
 |------------------|-----------|---------|
-| **UVC** (Universal Values Corpus) | Layer 1: Identity | Curated cross-cultural corpus of values, "What3Words for ethics" |
+| **UVC** (Universal Value Coding) | Layer 1: Identity | Curated cross-cultural corpus of values, "What3Words for ethics" |
 | **CSM** (Constitutional Safety Minicode) | Layer 3: Semantics | Compact grammar for safety rules, adherence proofs |
 | **VCL** (Values Communication Layer) | Layer 4: Adaptation | Emoji-based symbolic encoding for context |
 | **VCP/M** (Messaging) | Layer 5: Messaging | Inter-agent message types, escalation, delivery semantics |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "value-context-protocol"
-version = "1.0.0"
+version = "4.2.0"
 description = "Value-Context Protocol - A specification for transporting constitutional values to AI systems"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/src/api/vcp.py
+++ b/python/src/api/vcp.py
@@ -15,7 +15,7 @@ from typing import Annotated, Any
 from api_routers.auth_dependencies import get_current_user
 from core.config.logging_config import get_logger
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 try:
     from services.feature_flags import is_feature_enabled
@@ -81,6 +81,8 @@ class CSM1ParseResponse(BaseModel):
 
 class ContextEncodeRequest(BaseModel):
     """Request to encode context dimensions."""
+
+    model_config = ConfigDict(extra="forbid")
 
     time: str | None = Field(
         None, description="Time context (morning, midday, evening, night)"

--- a/python/src/api/vcp.py
+++ b/python/src/api/vcp.py
@@ -100,10 +100,6 @@ class ContextEncodeRequest(BaseModel):
         None,
         description="Occasion (normal, celebration, mourning, emergency)",
     )
-    state: str | None = Field(
-        None,
-        description="Mental state (happy, anxious, tired, contemplative)",
-    )
     environment: str | None = Field(
         None, description="Physical environment"
     )
@@ -113,6 +109,48 @@ class ContextEncodeRequest(BaseModel):
     )
     constraints: list[str] | None = Field(
         None, description="Active constraints"
+    )
+    system_context: str | None = Field(
+        None,
+        description="System context (online, degraded, offline, sandboxed, testing)",
+    )
+    # ── VEP-0004 ────────────────────────────────────────────────────────
+    embodiment: str | None = Field(
+        None,
+        description="Embodiment (stationary, navigating, manipulating, carrying, emergency_stop)",
+    )
+    proximity: str | None = Field(
+        None,
+        description="Proximity (distant, same_room, nearby, close, contact)",
+    )
+    relationship: str | None = Field(
+        None,
+        description="Relationship (compound '{tie}:{function}', e.g. 'colleague:professional')",
+    )
+    formality: str | None = Field(
+        None,
+        description="Formality (casual, professional, formal, ceremonial)",
+    )
+    # ── Personal state (R-line, v3.1+) ──────────────────────────────────
+    cognitive_state: str | None = Field(
+        None,
+        description="Cognitive state, optional 'value:intensity' (e.g. 'focused:4')",
+    )
+    emotional_tone: str | None = Field(
+        None,
+        description="Emotional tone, optional 'value:intensity' (e.g. 'calm:5')",
+    )
+    energy_level: str | None = Field(
+        None,
+        description="Energy level, optional 'value:intensity' (e.g. 'rested:4')",
+    )
+    perceived_urgency: str | None = Field(
+        None,
+        description="Perceived urgency, optional 'value:intensity' (e.g. 'unhurried:2')",
+    )
+    body_signals: str | None = Field(
+        None,
+        description="Body signals, optional 'value:intensity' (e.g. 'neutral:1')",
     )
 
 
@@ -237,21 +275,36 @@ async def encode_context(
 
     encoder = ContextEncoder()
     context = encoder.encode(
+        # Situational (VCP v3.2, 13 dims)
         time=request.time,
         space=request.space,
         company=request.company,
         culture=request.culture,
         occasion=request.occasion,
-        state=request.state,
         environment=request.environment,
         agency=request.agency,
         constraints=request.constraints,
+        system_context=request.system_context,
+        # VEP-0004
+        embodiment=request.embodiment,
+        proximity=request.proximity,
+        relationship=request.relationship,
+        formality=request.formality,
+        # Personal state (R-line)
+        cognitive_state=request.cognitive_state,
+        emotional_tone=request.emotional_tone,
+        energy_level=request.energy_level,
+        perceived_urgency=request.perceived_urgency,
+        body_signals=request.body_signals,
     )
+
+    dimensions_set = [dim._name for dim in context.situational.keys()]
+    dimensions_set += [f"personal:{dim._name}" for dim in context.personal.keys()]
 
     return ContextEncodeResponse(
         wire_format=context.encode(),
         json_format=context.to_json(),
-        dimensions_set=[dim._name for dim in context.dimensions.keys()],
+        dimensions_set=dimensions_set,
     )
 
 

--- a/python/src/mcp/vcp_server.py
+++ b/python/src/mcp/vcp_server.py
@@ -223,15 +223,27 @@ async def _handle_encode_context(arguments: dict):
 
     encoder = ContextEncoder()
     context = encoder.encode(
+        # Situational (VCP v3.2, 13 dims)
         time=arguments.get("time"),
         space=arguments.get("space"),
         company=arguments.get("company"),
         culture=arguments.get("culture"),
         occasion=arguments.get("occasion"),
-        state=arguments.get("state"),
         environment=arguments.get("environment"),
         agency=arguments.get("agency"),
         constraints=arguments.get("constraints"),
+        system_context=arguments.get("system_context"),
+        # VEP-0004
+        embodiment=arguments.get("embodiment"),
+        proximity=arguments.get("proximity"),
+        relationship=arguments.get("relationship"),
+        formality=arguments.get("formality"),
+        # Personal state (R-line)
+        cognitive_state=arguments.get("cognitive_state"),
+        emotional_tone=arguments.get("emotional_tone"),
+        energy_level=arguments.get("energy_level"),
+        perceived_urgency=arguments.get("perceived_urgency"),
+        body_signals=arguments.get("body_signals"),
     )
 
     result = {

--- a/python/src/vcp/__init__.py
+++ b/python/src/vcp/__init__.py
@@ -138,7 +138,7 @@ from .types import (  # noqa: F401
     apply_decay,
 )
 
-__version__ = "4.0.0"  # VCP v4.0: v2.0 spec + robustness layer
+__version__ = "4.2.0"  # VCP v3.2 / VEP-0004 adaptation layer
 __all__ = [
     # Bundle
     "Bundle",

--- a/python/src/vcp/__init__.py
+++ b/python/src/vcp/__init__.py
@@ -20,6 +20,12 @@ from .adaptation import (  # noqa: F401
 )
 from .audit import AuditEntry, AuditLevel, AuditLogger  # noqa: F401
 from .bundle import Bundle, BundleBuilder, Manifest  # noqa: F401
+from .canonicalize import (  # noqa: F401
+    canonicalize_content,
+    canonicalize_manifest,
+    compute_content_hash,
+    verify_content_hash,
+)
 from .enforcement import (  # noqa: F401
     AdherenceLevelPlugin,
     BundleExpiryPlugin,
@@ -30,12 +36,6 @@ from .enforcement import (  # noqa: F401
     PDPEnforcer,
     PDPPlugin,
     RefusalBoundaryPlugin,
-)
-from .canonicalize import (  # noqa: F401
-    canonicalize_content,
-    canonicalize_manifest,
-    compute_content_hash,
-    verify_content_hash,
 )
 
 # VCP/I (Identity Layer)

--- a/python/src/vcp/__init__.py
+++ b/python/src/vcp/__init__.py
@@ -20,6 +20,17 @@ from .adaptation import (  # noqa: F401
 )
 from .audit import AuditEntry, AuditLevel, AuditLogger  # noqa: F401
 from .bundle import Bundle, BundleBuilder, Manifest  # noqa: F401
+from .enforcement import (  # noqa: F401
+    AdherenceLevelPlugin,
+    BundleExpiryPlugin,
+    DecisionType,
+    EnforcementResult,
+    EvaluationContext,
+    PDPDecision,
+    PDPEnforcer,
+    PDPPlugin,
+    RefusalBoundaryPlugin,
+)
 from .canonicalize import (  # noqa: F401
     canonicalize_content,
     canonicalize_manifest,
@@ -229,4 +240,14 @@ __all__ = [
     "get_field_privacy_level",
     "format_field_name",
     "generate_privacy_summary",
+    # PDP Enforcement
+    "PDPPlugin",
+    "PDPEnforcer",
+    "PDPDecision",
+    "DecisionType",
+    "EnforcementResult",
+    "EvaluationContext",
+    "RefusalBoundaryPlugin",
+    "AdherenceLevelPlugin",
+    "BundleExpiryPlugin",
 ]

--- a/python/src/vcp/adaptation/__init__.py
+++ b/python/src/vcp/adaptation/__init__.py
@@ -1,17 +1,28 @@
 """
-VCP/A (Adaptation Layer) - Context-aware adaptation.
+VCP/A (Adaptation Layer) — Context-aware adaptation.
 
-Provides context encoding, state tracking, and transition handling.
+Provides context encoding (VCP v3.2 / VEP-0004), state tracking, and
+transition handling.
 """
 
-from .context import ContextEncoder, Dimension, VCPContext
+from .context import (
+    ContextEncoder,
+    Dimension,  # backwards-compat alias → SituationalDimension
+    PersonalStateDimension,
+    PersonalState,
+    SituationalDimension,
+    VCPContext,
+)
 from .redis_state import HybridStateTracker, RedisStateTracker, get_sync_redis_client
 from .state import StateTracker, Transition, TransitionSeverity
 
 __all__ = [
     "VCPContext",
     "ContextEncoder",
-    "Dimension",
+    "SituationalDimension",
+    "PersonalStateDimension",
+    "PersonalState",
+    "Dimension",  # deprecated alias kept for backwards compatibility
     "StateTracker",
     "Transition",
     "TransitionSeverity",

--- a/python/src/vcp/adaptation/__init__.py
+++ b/python/src/vcp/adaptation/__init__.py
@@ -8,8 +8,8 @@ transition handling.
 from .context import (
     ContextEncoder,
     Dimension,  # backwards-compat alias → SituationalDimension
-    PersonalStateDimension,
     PersonalState,
+    PersonalStateDimension,
     SituationalDimension,
     VCPContext,
 )

--- a/python/src/vcp/adaptation/context.py
+++ b/python/src/vcp/adaptation/context.py
@@ -44,12 +44,11 @@ Conformance levels (per VEP-0004):
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
 from ..metrics import track_duration, vcp_context_encode_duration_seconds, vcp_context_encodes_total
-
 
 # ────────────────────────────────────────────────────────────────────────────
 # Wire-format constants

--- a/python/src/vcp/adaptation/context.py
+++ b/python/src/vcp/adaptation/context.py
@@ -1,11 +1,45 @@
 """
-VCP/A Enneagram Context Encoder.
+VCP/A Adaptation Layer context encoder (v3.2).
 
-Encodes context state across 9 dimensions using an enneagram-inspired structure.
-Each dimension can hold multiple values for complex context representation.
+Encodes context as 13 situational dimensions + 5 personal-state dimensions
+per CSM1 / VCP v3.2 and VEP-0004.
 
-Wire format: ⏰🌅|📍🏡|👥👶👨‍👩‍👧
-JSON format: {"time": ["morning"], "space": ["home"], "company": ["children", "family"]}
+Situational dimensions (positions 1-13):
+    1.  TIME          ⏰
+    2.  SPACE         📍
+    3.  COMPANY       👥
+    4.  CULTURE       🌍   (communication style, not nationality)
+    5.  OCCASION      🎭
+    6.  ENVIRONMENT   🌡️
+    7.  AGENCY        🔷
+    8.  CONSTRAINTS   🔶
+    9.  SYSTEM_CONTEXT 📡
+    10. EMBODIMENT    🧍   (VEP-0004)
+    11. PROXIMITY     ↔️   (VEP-0004)
+    12. RELATIONSHIP  🪢   (VEP-0004; compound "{tie}:{function}")
+    13. FORMALITY     🎩   (VEP-0004)
+
+Personal-state dimensions (R-line, v3.1+; positions 1-5 with optional 1-5 intensity):
+    1. COGNITIVE_STATE   🧠
+    2. EMOTIONAL_TONE    💭
+    3. ENERGY_LEVEL      🔋
+    4. PERCEIVED_URGENCY ⚡
+    5. BODY_SIGNALS      🩺
+
+Wire format:
+    <situational>‖<personal>
+where <situational> is pipe-separated symbol+value groups and <personal> is
+pipe-separated symbol+name[:intensity] groups. The U+2016 DOUBLE VERTICAL
+LINE ("‖") separates the two bands. The personal band and its separator
+are omitted if no personal dimensions are set.
+
+Example:
+    ⏰🌅|📍🏢|👥👔|🎭💼|🧍✋|↔️🤏|🪢colleague:professional|🎩💼‖🧠focused:4|💭calm:5
+
+Conformance levels (per VEP-0004):
+    VCP-Minimal  — 9 situational only (positions 1-9)
+    VCP-Standard — 9 situational + 5 personal (14 dims total)
+    VCP-Extended — 13 situational + 5 personal (18 dims total, incl. VEP-0004)
 """
 
 from __future__ import annotations
@@ -17,8 +51,21 @@ from typing import Any
 from ..metrics import track_duration, vcp_context_encode_duration_seconds, vcp_context_encodes_total
 
 
-class Dimension(Enum):
-    """9 context dimensions for VCP/A encoding."""
+# ────────────────────────────────────────────────────────────────────────────
+# Wire-format constants
+# ────────────────────────────────────────────────────────────────────────────
+
+PERSONAL_SEPARATOR = "\u2016"  # ‖  U+2016 DOUBLE VERTICAL LINE
+DIM_SEPARATOR = "|"
+INTENSITY_SEPARATOR = ":"
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Situational dimensions (positions 1-13)
+# ────────────────────────────────────────────────────────────────────────────
+
+class SituationalDimension(Enum):
+    """13 situational context dimensions for VCP/A encoding (VCP v3.2)."""
 
     TIME = (
         "time",
@@ -48,37 +95,101 @@ class Dimension(Enum):
         "culture",
         "🌍",
         4,
-        {"🌍": "global", "🇺🇸": "american", "🇪🇺": "european", "🇯🇵": "japanese"},
+        # Communication styles per CSM1 / VCP v3.2 — NOT nationalities.
+        {
+            "🔇": "high_context",
+            "📢": "low_context",
+            "🎩": "formal",
+            "😎": "casual",
+            "🌐": "mixed",
+        },
     )
     OCCASION = (
         "occasion",
         "🎭",
         5,
-        {"➖": "normal", "🎂": "celebration", "😢": "mourning", "🚨": "emergency"},
-    )
-    STATE = (
-        "state",
-        "🧠",
-        6,
-        {"😊": "happy", "😰": "anxious", "😴": "tired", "🤔": "contemplative", "😤": "frustrated"},
+        {
+            "➖": "normal",
+            "🎂": "celebration",
+            "😢": "mourning",
+            "🚨": "emergency",
+            "💼": "business",
+        },
     )
     ENVIRONMENT = (
         "environment",
         "🌡️",
-        7,
+        6,
         {"☀️": "comfortable", "🥵": "hot", "🥶": "cold", "🔇": "quiet", "🔊": "noisy"},
     )
     AGENCY = (
         "agency",
         "🔷",
-        8,
+        7,
         {"👑": "leader", "🤝": "peer", "📋": "subordinate", "🔐": "limited"},
     )
     CONSTRAINTS = (
         "constraints",
         "🔶",
-        9,
+        8,
         {"○": "minimal", "⚖️": "legal", "💸": "economic", "⏱️": "time"},
+    )
+    SYSTEM_CONTEXT = (
+        "system_context",
+        "📡",
+        9,
+        {
+            "🟢": "online",
+            "🟡": "degraded",
+            "🔴": "offline",
+            "🔒": "sandboxed",
+            "🧪": "testing",
+        },
+    )
+    # ── VEP-0004 (positions 10-13) ─────────────────────────────────────────
+    EMBODIMENT = (
+        "embodiment",
+        "🧍",
+        10,
+        {
+            "🪑": "stationary",
+            "🚶": "navigating",
+            "✋": "manipulating",
+            "📦": "carrying",
+            "🛑": "emergency_stop",
+        },
+    )
+    PROXIMITY = (
+        "proximity",
+        "↔️",
+        11,
+        {
+            "🌐": "distant",
+            "🏠": "same_room",
+            "👣": "nearby",
+            "🤏": "close",
+            "👆": "contact",
+        },
+    )
+    RELATIONSHIP = (
+        "relationship",
+        "🪢",
+        12,
+        # Compound grammar: "{tie}:{function}" — stored as raw string values.
+        # Example values: "colleague:professional", "friend:social",
+        # "family:caregiving", "stranger:service".
+        {},
+    )
+    FORMALITY = (
+        "formality",
+        "🎩",
+        13,
+        {
+            "😎": "casual",
+            "💼": "professional",
+            "🎓": "formal",
+            "🏛️": "ceremonial",
+        },
     )
 
     def __init__(self, name: str, symbol: str, position: int, values: dict[str, str]):
@@ -99,78 +210,278 @@ class Dimension(Enum):
     def values(self) -> dict[str, str]:
         return self._values
 
+    @property
+    def is_vep_0004(self) -> bool:
+        """Whether this dimension was introduced in VEP-0004 (positions 10-13)."""
+        return self._position >= 10
+
+    @property
+    def is_free_form(self) -> bool:
+        """Whether this dimension accepts raw-string values (no emoji vocab)."""
+        # RELATIONSHIP uses compound {tie}:{function} grammar, not an emoji table.
+        return self is SituationalDimension.RELATIONSHIP
+
     @classmethod
-    def from_name(cls, name: str) -> Dimension:
-        """Get dimension by name."""
+    def from_name(cls, name: str) -> SituationalDimension:
+        """Get dimension by name (case-insensitive)."""
         for dim in cls:
             if dim._name == name.lower():
                 return dim
-        raise ValueError(f"Unknown dimension: {name}")
+        raise ValueError(f"Unknown situational dimension: {name}")
 
 
-@dataclass
+# Backwards-compatible alias. Note: the v3.0 STATE dimension was removed in
+# v3.1 and replaced by the personal-state R-line (see PersonalStateDimension).
+# Code that imported `Dimension` for one of the surviving 8 dims continues
+# to work unchanged; `Dimension.STATE` no longer exists.
+Dimension = SituationalDimension
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Personal-state dimensions (R-line; v3.1+)
+# ────────────────────────────────────────────────────────────────────────────
+
+class PersonalStateDimension(Enum):
+    """5 personal-state dimensions (VCP v3.1+ R-line).
+
+    Note: `vcp.extensions.personal.PersonalDimension` is a separate str-enum
+    used by the decay-aware PersonalSignal model. This enum is purely for
+    wire-format encoding (symbol + position). The two cover the same domain
+    concept but are not interchangeable; the categorical vocabularies below
+    are non-normative documentation only — the wire format accepts any
+    string value.
+    """
+
+    COGNITIVE_STATE = (
+        "cognitive_state",
+        "🧠",
+        1,
+        {"focused", "scattered", "contemplative", "alert", "foggy"},
+    )
+    EMOTIONAL_TONE = (
+        "emotional_tone",
+        "💭",
+        2,
+        {"calm", "anxious", "joyful", "frustrated", "melancholy", "neutral"},
+    )
+    ENERGY_LEVEL = (
+        "energy_level",
+        "🔋",
+        3,
+        {"depleted", "low", "moderate", "rested", "energized"},
+    )
+    PERCEIVED_URGENCY = (
+        "perceived_urgency",
+        "⚡",
+        4,
+        {"unhurried", "mild_urgency", "pressing", "critical"},
+    )
+    BODY_SIGNALS = (
+        "body_signals",
+        "🩺",
+        5,
+        {"neutral", "tense", "relaxed", "discomfort", "pain"},
+    )
+
+    def __init__(self, name: str, symbol: str, position: int, values: set[str]):
+        self._name = name
+        self._symbol = symbol
+        self._position = position
+        self._values = values
+
+    @property
+    def symbol(self) -> str:
+        return self._symbol
+
+    @property
+    def position(self) -> int:
+        return self._position
+
+    @property
+    def values(self) -> set[str]:
+        return self._values
+
+    @classmethod
+    def from_name(cls, name: str) -> PersonalStateDimension:
+        """Get dimension by name (case-insensitive)."""
+        for dim in cls:
+            if dim._name == name.lower():
+                return dim
+        raise ValueError(f"Unknown personal dimension: {name}")
+
+    @classmethod
+    def from_symbol(cls, symbol: str) -> PersonalStateDimension | None:
+        """Get dimension by its emoji symbol, or None if not found."""
+        for dim in cls:
+            if dim._symbol == symbol:
+                return dim
+        return None
+
+
+@dataclass(frozen=True)
+class PersonalState:
+    """A single personal-state value with optional 1-5 intensity."""
+
+    value: str
+    intensity: int | None = None  # 1-5 if present; None means unspecified
+
+    def __post_init__(self) -> None:
+        if self.intensity is not None and not (1 <= self.intensity <= 5):
+            raise ValueError(
+                f"PersonalState intensity must be 1-5 or None, got {self.intensity}"
+            )
+
+    def encode(self) -> str:
+        """Encode to wire segment (without dimension symbol)."""
+        if self.intensity is None:
+            return self.value
+        return f"{self.value}{INTENSITY_SEPARATOR}{self.intensity}"
+
+    @classmethod
+    def decode(cls, segment: str) -> PersonalState:
+        """Decode a wire segment like 'focused:4' or 'calm'."""
+        if INTENSITY_SEPARATOR in segment:
+            value, intensity_str = segment.rsplit(INTENSITY_SEPARATOR, 1)
+            try:
+                intensity = int(intensity_str)
+            except ValueError:
+                # Not an intensity — whole segment is the value (edge case).
+                return cls(value=segment)
+            return cls(value=value, intensity=intensity)
+        return cls(value=segment)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# VCPContext
+# ────────────────────────────────────────────────────────────────────────────
+
 class VCPContext:
-    """Encoded VCP/A context state."""
+    """Encoded VCP/A context state (v3.2).
 
-    dimensions: dict[Dimension, list[str]] = field(default_factory=dict)
+    Backwards-compat: accepts `dimensions=` as an alias for `situational=`
+    in the constructor, and exposes `.dimensions` as a read-write alias for
+    `.situational`. New code should use `.situational` and `.personal`.
+    """
 
+    __slots__ = ("situational", "personal")
+
+    def __init__(
+        self,
+        situational: dict[SituationalDimension, list[str]] | None = None,
+        personal: dict[PersonalStateDimension, PersonalState] | None = None,
+        *,
+        dimensions: dict[SituationalDimension, list[str]] | None = None,
+    ) -> None:
+        if situational is not None and dimensions is not None:
+            raise TypeError(
+                "VCPContext: pass either 'situational' or the deprecated "
+                "'dimensions' alias — not both."
+            )
+        object.__setattr__(
+            self, "situational", dict(situational or dimensions or {})
+        )
+        object.__setattr__(self, "personal", dict(personal or {}))
+
+    # Backwards-compat alias: older v3.0 code used `ctx.dimensions[Dimension.TIME]`
+    # both for reads and for mutation. We expose a writable attribute-style alias
+    # that points to the same dict as `.situational`.
+    @property
+    def dimensions(self) -> dict[SituationalDimension, list[str]]:
+        """Backwards-compatible alias for `situational` (same dict, live)."""
+        return self.situational
+
+    @dimensions.setter
+    def dimensions(self, value: dict[SituationalDimension, list[str]]) -> None:
+        object.__setattr__(self, "situational", dict(value))
+
+    # ── Wire format ────────────────────────────────────────────────────────
     def encode(self) -> str:
         """Encode to wire format.
 
-        Format: ⏰🌅|📍🏡|👥👶👨‍👩‍👧 (symbol + values, pipe-separated)
-
-        Returns:
-            Wire-format string
+        Format:
+            <situational>‖<personal>
+        Situational is `symbol+values` per dim, pipe-separated. Personal is
+        `symbol+value[:intensity]` per dim, pipe-separated. The ‖ separator
+        and personal band are omitted when no personal dims are set.
         """
-        parts = []
-        for dim in Dimension:
-            if dim in self.dimensions and self.dimensions[dim]:
-                values = "".join(self.dimensions[dim])
-                parts.append(f"{dim.symbol}{values}")
-        return "|".join(parts)
+        sit_parts: list[str] = []
+        for dim in SituationalDimension:
+            if dim in self.situational and self.situational[dim]:
+                values = "".join(self.situational[dim])
+                sit_parts.append(f"{dim.symbol}{values}")
+        situational = DIM_SEPARATOR.join(sit_parts)
+
+        if not self.personal:
+            return situational
+
+        per_parts: list[str] = []
+        for dim in PersonalStateDimension:
+            if dim in self.personal:
+                state = self.personal[dim]
+                per_parts.append(f"{dim.symbol}{state.encode()}")
+        personal = DIM_SEPARATOR.join(per_parts)
+
+        if not situational:
+            return PERSONAL_SEPARATOR + personal
+        return f"{situational}{PERSONAL_SEPARATOR}{personal}"
 
     @classmethod
     def decode(cls, encoded: str) -> VCPContext:
-        """Decode from wire format.
+        """Decode from wire format."""
+        situational: dict[SituationalDimension, list[str]] = {}
+        personal: dict[PersonalStateDimension, PersonalState] = {}
 
-        Args:
-            encoded: Wire-format string
-
-        Returns:
-            Decoded VCPContext
-        """
-        dimensions: dict[Dimension, list[str]] = {}
         if not encoded:
-            return cls(dimensions=dimensions)
+            return cls()
 
-        parts = encoded.split("|")
-        for part in parts:
+        # Split on personal-state separator ‖ first.
+        if PERSONAL_SEPARATOR in encoded:
+            sit_part, per_part = encoded.split(PERSONAL_SEPARATOR, 1)
+        else:
+            sit_part, per_part = encoded, ""
+
+        # Decode situational band.
+        for part in sit_part.split(DIM_SEPARATOR):
             if not part:
                 continue
-
-            # First character(s) might be multi-byte emoji - find matching dimension
-            for dim in Dimension:
+            for dim in SituationalDimension:
                 if part.startswith(dim.symbol):
-                    # Extract values after symbol
-                    values_str = part[len(dim.symbol) :]
-                    if values_str:
-                        # Each value is an emoji - extract them
-                        values = cls._extract_emojis(values_str)
+                    raw = part[len(dim.symbol):]
+                    if not raw:
+                        break
+                    if dim.is_free_form:
+                        # RELATIONSHIP: raw string preserved intact
+                        situational[dim] = [raw]
+                    else:
+                        values = cls._extract_emojis(raw)
                         if values:
-                            dimensions[dim] = values
+                            situational[dim] = values
+                        else:
+                            # Fallback: unknown value format, store raw.
+                            situational[dim] = [raw]
                     break
 
-        return cls(dimensions=dimensions)
+        # Decode personal-state band.
+        for part in per_part.split(DIM_SEPARATOR):
+            if not part:
+                continue
+            for dim in PersonalStateDimension:
+                if part.startswith(dim.symbol):
+                    raw = part[len(dim.symbol):]
+                    if raw:
+                        personal[dim] = PersonalState.decode(raw)
+                    break
+
+        return cls(situational=situational, personal=personal)
 
     @staticmethod
     def _extract_emojis(s: str) -> list[str]:
         """Extract individual emojis from a string.
 
-        Handles multi-codepoint emojis like 👨‍👩‍👧.
+        Handles multi-codepoint sequences (ZWJ families, variation selectors).
         """
         import re
 
-        # Unicode emoji pattern (simplified but covers most cases)
         emoji_pattern = re.compile(
             r"[\U0001F300-\U0001F9FF]"  # Most emojis
             r"|[\U0001F600-\U0001F64F]"  # Emoticons
@@ -183,151 +494,254 @@ class VCPContext:
             r"|\u274C"  # Cross mark
             r"|\u2139"  # Info
             r"|\u25CB"  # Circle
-            r"|(?:[\U0001F468-\U0001F469][\u200D]?)+[\U0001F466-\U0001F469]?"  # Family
+            r"|(?:[\U0001F468-\U0001F469][\u200D]?)+[\U0001F466-\U0001F469]?"
         )
         return emoji_pattern.findall(s)
 
-    def to_json(self) -> dict[str, list[str]]:
+    # ── JSON ───────────────────────────────────────────────────────────────
+    def to_json(self) -> dict[str, Any]:
         """Convert to JSON-serializable dict.
 
-        Returns:
-            Dict with dimension names as keys and value lists
+        Shape:
+            {
+              "situational": {"time": ["🌅"], ...},
+              "personal":    {"cognitive_state": {"value": "focused", "intensity": 4}, ...}
+            }
         """
-        return {dim._name: self.dimensions.get(dim, []) for dim in Dimension}
+        out: dict[str, Any] = {
+            "situational": {
+                dim._name: self.situational.get(dim, []) for dim in SituationalDimension
+            },
+            "personal": {
+                dim._name: {
+                    "value": self.personal[dim].value,
+                    "intensity": self.personal[dim].intensity,
+                }
+                for dim in PersonalStateDimension
+                if dim in self.personal
+            },
+        }
+        return out
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> VCPContext:
         """Create from JSON dict.
 
-        Args:
-            data: Dict with dimension names as keys
-
-        Returns:
-            VCPContext instance
+        Accepts either the v3.2 nested shape `{situational: {...}, personal: {...}}`
+        or the legacy flat shape `{"time": [...], "space": [...], ...}`.
         """
-        dimensions: dict[Dimension, list[str]] = {}
-        for dim in Dimension:
+        situational: dict[SituationalDimension, list[str]] = {}
+        personal: dict[PersonalStateDimension, PersonalState] = {}
+
+        sit_src: dict[str, Any]
+        per_src: dict[str, Any]
+
+        if "situational" in data or "personal" in data:
+            sit_src = data.get("situational", {}) or {}
+            per_src = data.get("personal", {}) or {}
+        else:
+            # Legacy flat shape — everything is situational.
+            sit_src = data
+            per_src = {}
+
+        for dim in SituationalDimension:
             key = dim._name
-            if key in data and data[key]:
-                values = data[key] if isinstance(data[key], list) else [data[key]]
-                dimensions[dim] = values
-        return cls(dimensions=dimensions)
+            if key in sit_src and sit_src[key]:
+                values = sit_src[key] if isinstance(sit_src[key], list) else [sit_src[key]]
+                situational[dim] = list(values)
 
-    def get(self, dimension: Dimension) -> list[str]:
-        """Get values for a dimension.
+        for dim in PersonalStateDimension:
+            key = dim._name
+            if key in per_src and per_src[key]:
+                entry = per_src[key]
+                if isinstance(entry, str):
+                    personal[dim] = PersonalState.decode(entry)
+                elif isinstance(entry, dict):
+                    personal[dim] = PersonalState(
+                        value=entry["value"],
+                        intensity=entry.get("intensity"),
+                    )
 
-        Args:
-            dimension: Dimension to query
+        return cls(situational=situational, personal=personal)
 
-        Returns:
-            List of values (empty if not set)
+    # ── Accessors ──────────────────────────────────────────────────────────
+    def get(self, dimension: SituationalDimension) -> list[str]:
+        """Get values for a situational dimension."""
+        return self.situational.get(dimension, [])
+
+    def get_personal(self, dimension: PersonalStateDimension) -> PersonalState | None:
+        """Get value for a personal-state dimension."""
+        return self.personal.get(dimension)
+
+    def set(
+        self, dimension: SituationalDimension, values: list[str]
+    ) -> VCPContext:
+        """Return new context with situational dimension values set."""
+        new_sit = dict(self.situational)
+        new_sit[dimension] = list(values)
+        return VCPContext(situational=new_sit, personal=dict(self.personal))
+
+    def set_personal(
+        self,
+        dimension: PersonalStateDimension,
+        value: str,
+        intensity: int | None = None,
+    ) -> VCPContext:
+        """Return new context with personal-state dimension set."""
+        new_per = dict(self.personal)
+        new_per[dimension] = PersonalState(value=value, intensity=intensity)
+        return VCPContext(situational=dict(self.situational), personal=new_per)
+
+    def has(self, dimension: SituationalDimension | PersonalStateDimension) -> bool:
+        """Check if dimension has any value set."""
+        if isinstance(dimension, SituationalDimension):
+            return bool(self.situational.get(dimension))
+        return dimension in self.personal
+
+    # ── Conformance ────────────────────────────────────────────────────────
+    def conformance_level(self) -> str:
+        """Classify this context by VCP conformance level.
+
+        Returns one of:
+            "VCP-Minimal"  — only core 9 situational (positions 1-9)
+            "VCP-Standard" — core 9 + any personal dims (no VEP-0004)
+            "VCP-Extended" — includes at least one VEP-0004 dim (positions 10-13)
         """
-        return self.dimensions.get(dimension, [])
+        uses_vep_0004 = any(d.is_vep_0004 for d in self.situational)
+        if uses_vep_0004:
+            return "VCP-Extended"
+        if self.personal:
+            return "VCP-Standard"
+        return "VCP-Minimal"
 
-    def set(self, dimension: Dimension, values: list[str]) -> VCPContext:
-        """Return new context with dimension values set.
-
-        Args:
-            dimension: Dimension to set
-            values: Values to set
-
-        Returns:
-            New VCPContext with updated dimension
-        """
-        new_dims = dict(self.dimensions)
-        new_dims[dimension] = list(values)
-        return VCPContext(dimensions=new_dims)
-
-    def has(self, dimension: Dimension) -> bool:
-        """Check if dimension has any values.
-
-        Args:
-            dimension: Dimension to check
-
-        Returns:
-            True if dimension has values
-        """
-        return bool(self.dimensions.get(dimension))
-
+    # ── Dunders ────────────────────────────────────────────────────────────
     def __bool__(self) -> bool:
-        """Context is truthy if any dimension has values."""
-        return any(self.dimensions.values())
+        return any(self.situational.values()) or bool(self.personal)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, VCPContext):
             return NotImplemented
-        return self.dimensions == other.dimensions
+        return self.situational == other.situational and self.personal == other.personal
 
+    def __hash__(self) -> int:  # noqa: D401
+        # Contexts aren't ordinarily hashable because they hold lists/dicts,
+        # but override here to mirror the frozen-style equality. Use encode()
+        # output as the hash basis.
+        return hash(self.encode())
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# ContextEncoder
+# ────────────────────────────────────────────────────────────────────────────
 
 class ContextEncoder:
-    """Build VCP/A contexts from various inputs."""
+    """Build VCP/A contexts from keyword inputs.
+
+    Situational dim kwargs accept either the emoji (pass-through) or the
+    human-readable value name (looked up in the dimension's emoji table).
+    RELATIONSHIP accepts the raw compound `{tie}:{function}` string.
+    Personal-state kwargs accept a string value and optional intensity.
+    """
 
     def encode(
         self,
+        # ── Core 9 situational ────────────────────────────────────────────
         time: str | None = None,
         space: str | None = None,
         company: list[str] | str | None = None,
         culture: str | None = None,
         occasion: str | None = None,
-        state: str | None = None,
         environment: str | None = None,
         agency: str | None = None,
         constraints: list[str] | str | None = None,
+        system_context: str | None = None,
+        # ── VEP-0004 (positions 10-13) ────────────────────────────────────
+        embodiment: str | None = None,
+        proximity: str | None = None,
+        relationship: str | None = None,  # raw "{tie}:{function}"
+        formality: str | None = None,
+        # ── Personal-state (R-line) ───────────────────────────────────────
+        cognitive_state: tuple[str, int] | str | None = None,
+        emotional_tone: tuple[str, int] | str | None = None,
+        energy_level: tuple[str, int] | str | None = None,
+        perceived_urgency: tuple[str, int] | str | None = None,
+        body_signals: tuple[str, int] | str | None = None,
     ) -> VCPContext:
-        """Encode context from keyword arguments.
+        """Build a VCPContext from keyword inputs.
 
-        Args:
-            time: Time context (morning, midday, evening, night)
-            space: Space context (home, office, school, etc.)
-            company: Company context (alone, children, colleagues, etc.)
-            culture: Cultural context
-            occasion: Occasion (normal, celebration, mourning, emergency)
-            state: Mental state
-            environment: Physical environment
-            agency: Agency level (leader, peer, subordinate, limited)
-            constraints: Active constraints
-
-        Returns:
-            Encoded VCPContext
+        Each personal-state kwarg may be either a bare string ("focused") or
+        a (value, intensity) tuple ("focused", 4).
         """
         vcp_context_encodes_total.inc()
         with track_duration(vcp_context_encode_duration_seconds):
-            dimensions: dict[Dimension, list[str]] = {}
+            situational: dict[SituationalDimension, list[str]] = {}
+            personal: dict[PersonalStateDimension, PersonalState] = {}
 
-            mappings = [
-                (Dimension.TIME, time),
-                (Dimension.SPACE, space),
-                (Dimension.COMPANY, company),
-                (Dimension.CULTURE, culture),
-                (Dimension.OCCASION, occasion),
-                (Dimension.STATE, state),
-                (Dimension.ENVIRONMENT, environment),
-                (Dimension.AGENCY, agency),
-                (Dimension.CONSTRAINTS, constraints),
+            sit_map = [
+                (SituationalDimension.TIME, time),
+                (SituationalDimension.SPACE, space),
+                (SituationalDimension.COMPANY, company),
+                (SituationalDimension.CULTURE, culture),
+                (SituationalDimension.OCCASION, occasion),
+                (SituationalDimension.ENVIRONMENT, environment),
+                (SituationalDimension.AGENCY, agency),
+                (SituationalDimension.CONSTRAINTS, constraints),
+                (SituationalDimension.SYSTEM_CONTEXT, system_context),
+                (SituationalDimension.EMBODIMENT, embodiment),
+                (SituationalDimension.PROXIMITY, proximity),
+                (SituationalDimension.RELATIONSHIP, relationship),
+                (SituationalDimension.FORMALITY, formality),
             ]
 
-            for dim, value in mappings:
-                if value:
+            for dim, value in sit_map:
+                if value is None:
+                    continue
+                if dim.is_free_form:
+                    # RELATIONSHIP: pass through as-is
                     if isinstance(value, str):
-                        emoji = self._lookup_emoji(dim, value)
-                        if emoji:
-                            dimensions[dim] = [emoji]
-                    elif isinstance(value, list):
-                        emojis = [self._lookup_emoji(dim, v) for v in value]
-                        dimensions[dim] = [e for e in emojis if e]
+                        situational[dim] = [value]
+                    continue
+                if isinstance(value, str):
+                    emoji = self._lookup(dim, value)
+                    if emoji:
+                        situational[dim] = [emoji]
+                elif isinstance(value, list):
+                    emojis = [self._lookup(dim, v) for v in value]
+                    filtered = [e for e in emojis if e]
+                    if filtered:
+                        situational[dim] = filtered
 
-            return VCPContext(dimensions=dimensions)
+            per_map = [
+                (PersonalStateDimension.COGNITIVE_STATE, cognitive_state),
+                (PersonalStateDimension.EMOTIONAL_TONE, emotional_tone),
+                (PersonalStateDimension.ENERGY_LEVEL, energy_level),
+                (PersonalStateDimension.PERCEIVED_URGENCY, perceived_urgency),
+                (PersonalStateDimension.BODY_SIGNALS, body_signals),
+            ]
 
-    def _lookup_emoji(self, dim: Dimension, value: str) -> str | None:
-        """Look up emoji for a value.
+            for dim, raw in per_map:
+                if raw is None:
+                    continue
+                if isinstance(raw, tuple):
+                    val, intensity = raw
+                    personal[dim] = PersonalState(value=val, intensity=intensity)
+                elif isinstance(raw, str):
+                    personal[dim] = PersonalState.decode(raw)
 
-        Args:
-            dim: Dimension
-            value: Value name
+            return VCPContext(situational=situational, personal=personal)
 
-        Returns:
-            Emoji if found, None otherwise
+    def _lookup(self, dim: SituationalDimension, value: str) -> str | None:
+        """Resolve a value to its emoji representation.
+
+        Accepts either the emoji itself (pass-through) or the value name.
+        Returns the emoji or None if unknown.
         """
+        if not value:
+            return None
+        # Pass-through: already an emoji registered in the dim's table.
+        if value in dim.values:
+            return value
+        # Name lookup.
         value_lower = value.lower()
         for emoji, name in dim.values.items():
             if name == value_lower:

--- a/python/src/vcp/adaptation/context.py
+++ b/python/src/vcp/adaptation/context.py
@@ -177,7 +177,7 @@ class SituationalDimension(Enum):
         # Compound grammar: "{tie}:{function}" — stored as raw string values.
         # Example values: "colleague:professional", "friend:social",
         # "family:caregiving", "stranger:service".
-        {},
+        dict[str, str](),
     )
     FORMALITY = (
         "formality",
@@ -364,6 +364,9 @@ class VCPContext:
 
     __slots__ = ("situational", "personal")
 
+    situational: dict[SituationalDimension, list[str]]
+    personal: dict[PersonalStateDimension, PersonalState]
+
     def __init__(
         self,
         situational: dict[SituationalDimension, list[str]] | None = None,
@@ -414,10 +417,10 @@ class VCPContext:
             return situational
 
         per_parts: list[str] = []
-        for dim in PersonalStateDimension:
-            if dim in self.personal:
-                state = self.personal[dim]
-                per_parts.append(f"{dim.symbol}{state.encode()}")
+        for pdim in PersonalStateDimension:
+            if pdim in self.personal:
+                state = self.personal[pdim]
+                per_parts.append(f"{pdim.symbol}{state.encode()}")
         personal = DIM_SEPARATOR.join(per_parts)
 
         if not situational:
@@ -464,11 +467,11 @@ class VCPContext:
         for part in per_part.split(DIM_SEPARATOR):
             if not part:
                 continue
-            for dim in PersonalStateDimension:
-                if part.startswith(dim.symbol):
-                    raw = part[len(dim.symbol):]
+            for pdim in PersonalStateDimension:
+                if part.startswith(pdim.symbol):
+                    raw = part[len(pdim.symbol):]
                     if raw:
-                        personal[dim] = PersonalState.decode(raw)
+                        personal[pdim] = PersonalState.decode(raw)
                     break
 
         return cls(situational=situational, personal=personal)
@@ -512,12 +515,12 @@ class VCPContext:
                 dim._name: self.situational.get(dim, []) for dim in SituationalDimension
             },
             "personal": {
-                dim._name: {
-                    "value": self.personal[dim].value,
-                    "intensity": self.personal[dim].intensity,
+                pdim._name: {
+                    "value": self.personal[pdim].value,
+                    "intensity": self.personal[pdim].intensity,
                 }
-                for dim in PersonalStateDimension
-                if dim in self.personal
+                for pdim in PersonalStateDimension
+                if pdim in self.personal
             },
         }
         return out
@@ -549,14 +552,14 @@ class VCPContext:
                 values = sit_src[key] if isinstance(sit_src[key], list) else [sit_src[key]]
                 situational[dim] = list(values)
 
-        for dim in PersonalStateDimension:
-            key = dim._name
+        for pdim in PersonalStateDimension:
+            key = pdim._name
             if key in per_src and per_src[key]:
                 entry = per_src[key]
                 if isinstance(entry, str):
-                    personal[dim] = PersonalState.decode(entry)
+                    personal[pdim] = PersonalState.decode(entry)
                 elif isinstance(entry, dict):
-                    personal[dim] = PersonalState(
+                    personal[pdim] = PersonalState(
                         value=entry["value"],
                         intensity=entry.get("intensity"),
                     )
@@ -718,14 +721,14 @@ class ContextEncoder:
                 (PersonalStateDimension.BODY_SIGNALS, body_signals),
             ]
 
-            for dim, raw in per_map:
+            for pdim, raw in per_map:
                 if raw is None:
                     continue
                 if isinstance(raw, tuple):
                     val, intensity = raw
-                    personal[dim] = PersonalState(value=val, intensity=intensity)
+                    personal[pdim] = PersonalState(value=val, intensity=intensity)
                 elif isinstance(raw, str):
-                    personal[dim] = PersonalState.decode(raw)
+                    personal[pdim] = PersonalState.decode(raw)
 
             return VCPContext(situational=situational, personal=personal)
 

--- a/python/src/vcp/audit.py
+++ b/python/src/vcp/audit.py
@@ -142,6 +142,7 @@ class AuditLogger:
         self.level = level
         self._log_callback = log_callback
         self._entries: list[AuditEntry] = []
+        self._exported_paths: list[str] = []
         self._lock = threading.Lock()
 
     def log_verification(
@@ -329,20 +330,24 @@ class AuditLogger:
     def purge_by_session(self, session_id: str) -> dict[str, Any]:
         """Purge all audit entries for a session (GDPR right to erasure).
 
-        **Scope**: This method purges the in-memory entry list only. It does
-        NOT touch data previously written via :meth:`export_json`, delivered
-        via ``log_callback``, or persisted to external stores (Redis, database).
-        Callers are responsible for propagating the purge to those sinks.
+        Purges matching entries from:
+        1. The in-memory entry list
+        2. Any JSON files previously written via :meth:`export_json`
 
-        A tombstone receipt is returned so that compliance can be demonstrated
-        to a regulator.
+        Data delivered via ``log_callback`` or persisted to external stores
+        (Redis, database) is NOT covered. Callers are responsible for
+        propagating the purge to those sinks — the ``PURGE_TOMBSTONE``
+        callback entry is emitted to facilitate this.
+
+        A tombstone receipt is returned so that compliance can be
+        demonstrated to a regulator.
 
         Args:
             session_id: Raw session identifier (will be hashed for comparison)
 
         Returns:
             Tombstone receipt dict with purge_id, timestamp, entries_removed,
-            session_id_hash, and scope description.
+            files_purged, and scope description.
         """
         target_hash = _hash_for_privacy(session_id)
         with self._lock:
@@ -351,7 +356,12 @@ class AuditLogger:
                 e for e in self._entries if e.session_id_hash != target_hash
             ]
             removed = before - len(self._entries)
-        if removed > 0:
+
+        # Scrub exported JSON files
+        files_purged = self._purge_exported_files(target_hash)
+        total_file_entries = sum(files_purged.values())
+
+        if removed > 0 or total_file_entries > 0:
             vcp_audit_events_total.labels(event_type="purge").inc()
 
         purge_id = str(uuid.uuid4())
@@ -359,22 +369,26 @@ class AuditLogger:
             "purge_id": purge_id,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "entries_removed": removed,
-            "scope": "in-memory audit entries only",
+            "file_entries_removed": total_file_entries,
+            "files_purged": files_purged,
+            "scope": "in-memory audit entries + tracked exported JSON files",
             "note": (
-                "This purge covers the in-memory audit log. Data previously "
-                "exported via export_json(), delivered via log_callback, or "
-                "persisted to external stores must be purged separately."
+                "This purge covers the in-memory audit log and all JSON files "
+                "previously exported via export_json(). Data delivered via "
+                "log_callback or persisted to external stores (Redis, database) "
+                "must be purged separately by the caller."
             ),
         }
 
-        if self._log_callback and removed > 0:
-            # Emit a synthetic audit entry so the callback sink knows
-            # a purge occurred and can act on it.
+        if self._log_callback and (removed > 0 or total_file_entries > 0):
             purge_entry = AuditEntry(
                 timestamp=datetime.now(timezone.utc),
                 session_id_hash=target_hash,
                 verification_result="PURGE_TOMBSTONE",
-                checks_passed=[f"removed:{removed}"],
+                checks_passed=[
+                    f"memory_removed:{removed}",
+                    f"file_removed:{total_file_entries}",
+                ],
                 bundle_id_hash=purge_id,
                 content_hash="n/a",
                 issuer_hash="n/a",
@@ -387,7 +401,52 @@ class AuditLogger:
         return tombstone
 
     def export_json(self, path: str) -> None:
-        """Export entries to JSON file."""
+        """Export entries to JSON file.
+
+        The path is tracked so that :meth:`purge_by_session` can also
+        scrub session data from previously exported files.
+        """
         with open(path, "w", encoding="utf-8") as f:
             entries = [e.to_dict() for e in self._entries]
             json.dump({"entries": entries}, f, indent=2)
+        if path not in self._exported_paths:
+            self._exported_paths.append(path)
+
+    def _purge_exported_files(self, session_id_hash: str) -> dict[str, int]:
+        """Remove entries matching session_id_hash from all exported JSON files.
+
+        Rewrites each file in-place (atomic replace). Files that no longer
+        exist are silently skipped and removed from the tracking list.
+
+        Returns:
+            Dict mapping file path to number of entries removed from that file.
+        """
+        results: dict[str, int] = {}
+        surviving_paths: list[str] = []
+
+        for path in self._exported_paths:
+            if not os.path.isfile(path):
+                continue
+            surviving_paths.append(path)
+
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+
+            entries = data.get("entries", [])
+            before = len(entries)
+            filtered = [
+                e for e in entries
+                if e.get("session_id_hash") != session_id_hash
+            ]
+            removed = before - len(filtered)
+
+            if removed > 0:
+                tmp_path = path + ".purge.tmp"
+                data["entries"] = filtered
+                with open(tmp_path, "w", encoding="utf-8") as f:
+                    json.dump(data, f, indent=2)
+                os.replace(tmp_path, path)
+                results[path] = removed
+
+        self._exported_paths = surviving_paths
+        return results

--- a/python/src/vcp/audit.py
+++ b/python/src/vcp/audit.py
@@ -473,7 +473,7 @@ class AuditLogger:
                 continue
             surviving_paths.append(path)
 
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, encoding="utf-8") as f:
                 data = json.load(f)
 
             entries = data.get("entries", [])

--- a/python/src/vcp/audit.py
+++ b/python/src/vcp/audit.py
@@ -357,8 +357,9 @@ class AuditLogger:
             ]
             removed = before - len(self._entries)
 
-        # Scrub exported JSON files
-        files_purged = self._purge_exported_files(target_hash)
+            # Scrub exported JSON files while still holding the lock so
+            # concurrent export_json() calls cannot interleave.
+            files_purged = self._purge_exported_files(target_hash)
         total_file_entries = sum(files_purged.values())
 
         if removed > 0 or total_file_entries > 0:
@@ -406,11 +407,12 @@ class AuditLogger:
         The path is tracked so that :meth:`purge_by_session` can also
         scrub session data from previously exported files.
         """
-        with open(path, "w", encoding="utf-8") as f:
-            entries = [e.to_dict() for e in self._entries]
-            json.dump({"entries": entries}, f, indent=2)
-        if path not in self._exported_paths:
-            self._exported_paths.append(path)
+        with self._lock:
+            with open(path, "w", encoding="utf-8") as f:
+                entries = [e.to_dict() for e in self._entries]
+                json.dump({"entries": entries}, f, indent=2)
+            if path not in self._exported_paths:
+                self._exported_paths.append(path)
 
     def _purge_exported_files(self, session_id_hash: str) -> dict[str, int]:
         """Remove entries matching session_id_hash from all exported JSON files.

--- a/python/src/vcp/audit.py
+++ b/python/src/vcp/audit.py
@@ -6,6 +6,7 @@ Privacy-preserving audit logging for VCP operations.
 
 import hashlib
 import json
+import logging
 import os
 import threading
 import uuid
@@ -16,6 +17,8 @@ from enum import Enum
 from typing import Any
 
 from .metrics import vcp_audit_events_total
+
+logger = logging.getLogger(__name__)
 
 # Per-process random salt for privacy hashing. Makes hashes non-reversible
 # from known inputs while remaining deterministic within a process lifetime
@@ -143,6 +146,7 @@ class AuditLogger:
         self._log_callback = log_callback
         self._entries: list[AuditEntry] = []
         self._exported_paths: list[str] = []
+        self._purge_handlers: list[Callable[[str, str], dict[str, Any]]] = []
         self._lock = threading.Lock()
 
     def log_verification(
@@ -327,17 +331,33 @@ class AuditLogger:
         """Clear stored entries."""
         self._entries.clear()
 
+    def register_purge_handler(
+        self,
+        handler: Callable[[str, str], dict[str, Any]],
+    ) -> None:
+        """Register an external sink's purge handler.
+
+        When :meth:`purge_by_session` runs, each registered handler is
+        called with ``(session_id_hash, purge_id)`` and should delete
+        that session's data from its store, returning a dict describing
+        what was removed (included in the tombstone receipt).
+
+        If ``log_callback`` is set without any purge handler, purge_by_session
+        will log a warning — the callback sink likely holds data that won't
+        be reached.
+
+        Args:
+            handler: ``(session_id_hash: str, purge_id: str) -> dict[str, Any]``
+        """
+        self._purge_handlers.append(handler)
+
     def purge_by_session(self, session_id: str) -> dict[str, Any]:
         """Purge all audit entries for a session (GDPR right to erasure).
 
         Purges matching entries from:
         1. The in-memory entry list
         2. Any JSON files previously written via :meth:`export_json`
-
-        Data delivered via ``log_callback`` or persisted to external stores
-        (Redis, database) is NOT covered. Callers are responsible for
-        propagating the purge to those sinks — the ``PURGE_TOMBSTONE``
-        callback entry is emitted to facilitate this.
+        3. Any external sinks via registered purge handlers
 
         A tombstone receipt is returned so that compliance can be
         demonstrated to a regulator.
@@ -347,9 +367,11 @@ class AuditLogger:
 
         Returns:
             Tombstone receipt dict with purge_id, timestamp, entries_removed,
-            files_purged, and scope description.
+            files_purged, external_sink_results, and scope description.
         """
         target_hash = _hash_for_privacy(session_id)
+        purge_id = str(uuid.uuid4())
+
         with self._lock:
             before = len(self._entries)
             self._entries = [
@@ -362,26 +384,45 @@ class AuditLogger:
             files_purged = self._purge_exported_files(target_hash)
         total_file_entries = sum(files_purged.values())
 
-        if removed > 0 or total_file_entries > 0:
+        # Propagate purge to registered external sinks
+        external_results: list[dict[str, Any]] = []
+        for handler in self._purge_handlers:
+            try:
+                result = handler(target_hash, purge_id)
+                external_results.append(result)
+            except Exception:
+                logger.exception(
+                    "[GDPR] External purge handler failed for purge_id=%s",
+                    purge_id,
+                )
+                external_results.append({"error": "handler raised exception"})
+
+        # Warn if log_callback is set but no purge handler covers it
+        if self._log_callback and not self._purge_handlers:
+            logger.warning(
+                "[GDPR] log_callback is set but no purge handlers are registered. "
+                "Data delivered to the callback sink may not be purged. "
+                "Use register_purge_handler() to close this gap."
+            )
+
+        if removed > 0 or total_file_entries > 0 or external_results:
             vcp_audit_events_total.labels(event_type="purge").inc()
 
-        purge_id = str(uuid.uuid4())
+        scope_parts = ["in-memory audit entries", "tracked exported JSON files"]
+        if self._purge_handlers:
+            scope_parts.append(f"{len(self._purge_handlers)} external sink(s)")
+
         tombstone: dict[str, Any] = {
             "purge_id": purge_id,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "entries_removed": removed,
             "file_entries_removed": total_file_entries,
             "files_purged": files_purged,
-            "scope": "in-memory audit entries + tracked exported JSON files",
-            "note": (
-                "This purge covers the in-memory audit log and all JSON files "
-                "previously exported via export_json(). Data delivered via "
-                "log_callback or persisted to external stores (Redis, database) "
-                "must be purged separately by the caller."
-            ),
+            "external_sink_results": external_results,
+            "scope": " + ".join(scope_parts),
         }
 
-        if self._log_callback and (removed > 0 or total_file_entries > 0):
+        if self._log_callback and (removed > 0 or total_file_entries > 0 or external_results):
             purge_entry = AuditEntry(
                 timestamp=datetime.now(timezone.utc),
                 session_id_hash=target_hash,
@@ -389,6 +430,7 @@ class AuditLogger:
                 checks_passed=[
                     f"memory_removed:{removed}",
                     f"file_removed:{total_file_entries}",
+                    f"external_sinks:{len(external_results)}",
                 ],
                 bundle_id_hash=purge_id,
                 content_hash="n/a",

--- a/python/src/vcp/enforcement.py
+++ b/python/src/vcp/enforcement.py
@@ -364,7 +364,9 @@ class PDPEnforcer:
         )
 
         decisions: list[PDPDecision] = []
+        evaluated = 0
         for plugin in self._plugins:
+            evaluated += 1
             try:
                 decision = plugin.evaluate(ctx)
                 if decision is not None:
@@ -403,5 +405,5 @@ class PDPEnforcer:
             final_decision=final,
             decisions=decisions,
             duration_ms=duration_ms,
-            plugins_evaluated=len(self._plugins),
+            plugins_evaluated=evaluated,
         )

--- a/python/src/vcp/enforcement.py
+++ b/python/src/vcp/enforcement.py
@@ -1,0 +1,391 @@
+"""
+VCP PDP Enforcement Module
+
+Standalone policy enforcement for VCP bundles. Allows SDK consumers to
+enforce PDP-like decisions (allow/block/transform) against constitutional
+rules without depending on a full safety stack.
+
+This module provides:
+- PDPPlugin: Abstract interface for enforcement plugins
+- PDPDecision: Decision result with reason and evidence
+- PDPEnforcer: Orchestrator that runs plugins and produces decisions
+- Built-in plugins: RefusalBoundaryPlugin, AdherenceLevelPlugin
+
+Usage:
+    from vcp.enforcement import PDPEnforcer, RefusalBoundaryPlugin, AdherenceLevelPlugin
+
+    enforcer = PDPEnforcer()
+    enforcer.register(RefusalBoundaryPlugin())
+    enforcer.register(AdherenceLevelPlugin(min_adherence=3))
+
+    decision = enforcer.evaluate(bundle, content="user prompt here")
+    if decision.blocked:
+        print(f"Blocked: {decision.reason}")
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from .audit import AuditLogger
+from .types import EnforcementMode, VerificationResult
+
+logger = logging.getLogger(__name__)
+
+
+class DecisionType(Enum):
+    """PDP decision outcomes."""
+
+    ALLOW = "allow"
+    BLOCK = "block"
+    TRANSFORM = "transform"
+    ESCALATE = "escalate"
+
+
+@dataclass
+class PDPDecision:
+    """Result of a PDP evaluation."""
+
+    decision: DecisionType
+    reason: str
+    plugin_id: str
+    confidence: float = 1.0
+    evidence: dict[str, Any] = field(default_factory=dict)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @property
+    def blocked(self) -> bool:
+        return self.decision == DecisionType.BLOCK
+
+    @property
+    def allowed(self) -> bool:
+        return self.decision == DecisionType.ALLOW
+
+
+@dataclass
+class EvaluationContext:
+    """Context passed to plugins during evaluation."""
+
+    bundle: Any  # Bundle
+    content: str
+    session_id: str | None = None
+    user_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class PDPPlugin(ABC):
+    """Abstract base class for PDP enforcement plugins.
+
+    Implement `evaluate` to inspect a bundle and content, returning
+    a PDPDecision if the plugin has an opinion, or None to abstain.
+    """
+
+    @property
+    @abstractmethod
+    def plugin_id(self) -> str:
+        """Unique identifier for this plugin."""
+
+    @property
+    def priority(self) -> int:
+        """Lower runs first. Default 100."""
+        return 100
+
+    @abstractmethod
+    def evaluate(self, ctx: EvaluationContext) -> PDPDecision | None:
+        """Evaluate content against this plugin's rules.
+
+        Returns:
+            PDPDecision if the plugin has a verdict, None to abstain.
+        """
+
+
+class RefusalBoundaryPlugin(PDPPlugin):
+    """Enforces refusal boundaries declared in VCP bundles.
+
+    Checks that the bundle's verification is valid and applies the
+    enforcement mode (FAIL_CLOSED, ESCALATE, AUDIT_ONLY) from the
+    bundle's refusal boundary tokens.
+    """
+
+    @property
+    def plugin_id(self) -> str:
+        return "refusal_boundary"
+
+    @property
+    def priority(self) -> int:
+        return 10  # Run early — invalid bundles should be caught first
+
+    def __init__(
+        self,
+        mode: EnforcementMode = EnforcementMode.FAIL_CLOSED,
+    ) -> None:
+        self._mode = mode
+
+    def evaluate(self, ctx: EvaluationContext) -> PDPDecision | None:
+        bundle = ctx.bundle
+        if bundle is None:
+            if self._mode == EnforcementMode.FAIL_CLOSED:
+                return PDPDecision(
+                    decision=DecisionType.BLOCK,
+                    reason="No VCP bundle present — fail-closed",
+                    plugin_id=self.plugin_id,
+                )
+            return None
+
+        # Check bundle verification status if available
+        verification = ctx.metadata.get("verification_result")
+        if isinstance(verification, VerificationResult) and not verification.is_valid:
+            if self._mode == EnforcementMode.FAIL_CLOSED:
+                return PDPDecision(
+                    decision=DecisionType.BLOCK,
+                    reason=f"Bundle verification failed: {verification.name}",
+                    plugin_id=self.plugin_id,
+                    evidence={"verification_result": verification.name},
+                )
+            if self._mode == EnforcementMode.ESCALATE:
+                return PDPDecision(
+                    decision=DecisionType.ESCALATE,
+                    reason=f"Bundle verification failed: {verification.name}",
+                    plugin_id=self.plugin_id,
+                    evidence={"verification_result": verification.name},
+                )
+            # AUDIT_ONLY: log but allow
+            logger.warning(
+                "Bundle verification failed (%s) but enforcement is AUDIT_ONLY",
+                verification.name,
+            )
+
+        return None
+
+
+class AdherenceLevelPlugin(PDPPlugin):
+    """Enforces minimum adherence level from CSM1-encoded constitutions.
+
+    Adherence levels (0-5):
+        0: Advisory — no enforcement
+        1: Soft — gentle reminders
+        2: Moderate — some enforcement
+        3: Active — standard enforcement
+        4: Strict — strong enforcement
+        5: Absolute — no overrides
+    """
+
+    @property
+    def plugin_id(self) -> str:
+        return "adherence_level"
+
+    @property
+    def priority(self) -> int:
+        return 20
+
+    def __init__(self, min_adherence: int = 3) -> None:
+        if not 0 <= min_adherence <= 5:
+            raise ValueError(f"min_adherence must be 0-5, got {min_adherence}")
+        self._min_adherence = min_adherence
+
+    def evaluate(self, ctx: EvaluationContext) -> PDPDecision | None:
+        bundle = ctx.bundle
+        if bundle is None:
+            return None
+
+        # Extract adherence level from bundle metadata or manifest
+        adherence = ctx.metadata.get("adherence_level")
+        if adherence is None:
+            manifest_meta = getattr(bundle, "manifest", None)
+            if manifest_meta:
+                adherence = getattr(manifest_meta, "metadata", {}).get(
+                    "adherence_level"
+                )
+
+        if adherence is None:
+            return None
+
+        try:
+            adherence = int(adherence)
+        except (ValueError, TypeError):
+            return PDPDecision(
+                decision=DecisionType.BLOCK,
+                reason=f"Invalid adherence level: {adherence!r}",
+                plugin_id=self.plugin_id,
+            )
+
+        if adherence < self._min_adherence:
+            return PDPDecision(
+                decision=DecisionType.BLOCK,
+                reason=(
+                    f"Adherence level {adherence} below minimum {self._min_adherence}"
+                ),
+                plugin_id=self.plugin_id,
+                evidence={
+                    "adherence_level": adherence,
+                    "min_adherence": self._min_adherence,
+                },
+            )
+
+        return None
+
+
+class BundleExpiryPlugin(PDPPlugin):
+    """Blocks expired bundles."""
+
+    @property
+    def plugin_id(self) -> str:
+        return "bundle_expiry"
+
+    @property
+    def priority(self) -> int:
+        return 5  # Run very early
+
+    def evaluate(self, ctx: EvaluationContext) -> PDPDecision | None:
+        bundle = ctx.bundle
+        if bundle is None:
+            return None
+
+        manifest = getattr(bundle, "manifest", None)
+        if manifest is None:
+            return None
+
+        timestamps = getattr(manifest, "timestamps", None)
+        if timestamps is None:
+            return None
+
+        exp = getattr(timestamps, "exp", None)
+        if exp is None:
+            return None
+
+        now = datetime.now(timezone.utc)
+        if hasattr(exp, "tzinfo") and exp.tzinfo is None:
+            exp = exp.replace(tzinfo=timezone.utc)
+
+        if now > exp:
+            return PDPDecision(
+                decision=DecisionType.BLOCK,
+                reason=f"Bundle expired at {exp.isoformat()}",
+                plugin_id=self.plugin_id,
+                evidence={"expired_at": exp.isoformat(), "now": now.isoformat()},
+            )
+
+        return None
+
+
+@dataclass
+class EnforcementResult:
+    """Aggregate result from all plugins."""
+
+    final_decision: DecisionType
+    decisions: list[PDPDecision]
+    duration_ms: int
+    plugins_evaluated: int
+
+    @property
+    def blocked(self) -> bool:
+        return self.final_decision == DecisionType.BLOCK
+
+    @property
+    def allowed(self) -> bool:
+        return self.final_decision == DecisionType.ALLOW
+
+    @property
+    def blocking_reasons(self) -> list[str]:
+        return [
+            d.reason for d in self.decisions if d.decision == DecisionType.BLOCK
+        ]
+
+
+class PDPEnforcer:
+    """Orchestrates PDP plugin evaluation against VCP bundles.
+
+    Runs registered plugins in priority order. Any BLOCK decision
+    causes the final result to be BLOCK (fail-closed). ESCALATE
+    decisions are promoted to BLOCK if no escalation handler is set.
+
+    Optionally integrates with AuditLogger for decision logging.
+    """
+
+    def __init__(
+        self,
+        audit_logger: AuditLogger | None = None,
+        fail_closed: bool = True,
+    ) -> None:
+        self._plugins: list[PDPPlugin] = []
+        self._audit_logger = audit_logger
+        self._fail_closed = fail_closed
+
+    def register(self, plugin: PDPPlugin) -> None:
+        """Register an enforcement plugin."""
+        self._plugins.append(plugin)
+        self._plugins.sort(key=lambda p: p.priority)
+
+    def evaluate(
+        self,
+        bundle: Any,
+        content: str,
+        session_id: str | None = None,
+        user_id: str | None = None,
+        **metadata: Any,
+    ) -> EnforcementResult:
+        """Evaluate content against all registered plugins.
+
+        Args:
+            bundle: VCP Bundle (or None if no bundle present)
+            content: The content/prompt being evaluated
+            session_id: Optional session identifier
+            user_id: Optional user identifier
+            **metadata: Additional context (e.g. verification_result, adherence_level)
+
+        Returns:
+            EnforcementResult with aggregate decision from all plugins.
+        """
+        start = time.monotonic()
+
+        ctx = EvaluationContext(
+            bundle=bundle,
+            content=content,
+            session_id=session_id,
+            user_id=user_id,
+            metadata=metadata,
+        )
+
+        decisions: list[PDPDecision] = []
+        for plugin in self._plugins:
+            try:
+                decision = plugin.evaluate(ctx)
+                if decision is not None:
+                    decisions.append(decision)
+            except Exception:
+                logger.exception("Plugin %s raised an exception", plugin.plugin_id)
+                if self._fail_closed:
+                    decisions.append(
+                        PDPDecision(
+                            decision=DecisionType.BLOCK,
+                            reason=f"Plugin {plugin.plugin_id} crashed — fail-closed",
+                            plugin_id=plugin.plugin_id,
+                            confidence=1.0,
+                        )
+                    )
+
+        # Determine final decision: any BLOCK or ESCALATE → BLOCK
+        final = DecisionType.ALLOW
+        for d in decisions:
+            if d.decision == DecisionType.BLOCK:
+                final = DecisionType.BLOCK
+                break
+            if d.decision == DecisionType.ESCALATE:
+                final = DecisionType.BLOCK  # No escalation handler → fail-closed
+            if d.decision == DecisionType.TRANSFORM and final == DecisionType.ALLOW:
+                final = DecisionType.TRANSFORM
+
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        return EnforcementResult(
+            final_decision=final,
+            decisions=decisions,
+            duration_ms=duration_ms,
+            plugins_evaluated=len(self._plugins),
+        )

--- a/python/src/vcp/enforcement.py
+++ b/python/src/vcp/enforcement.py
@@ -2,7 +2,7 @@
 VCP PDP Enforcement Module
 
 Standalone policy enforcement for VCP bundles. Allows SDK consumers to
-enforce PDP-like decisions (allow/block/transform) against constitutional
+enforce PDP-like decisions (allow/block/modify/escalate) against constitutional
 rules without depending on a full safety stack.
 
 This module provides:
@@ -44,7 +44,7 @@ class DecisionType(Enum):
 
     ALLOW = "allow"
     BLOCK = "block"
-    TRANSFORM = "transform"
+    MODIFY = "modify"
     ESCALATE = "escalate"
 
 
@@ -396,8 +396,8 @@ class PDPEnforcer:
                     d.plugin_id,
                 )
                 final = DecisionType.BLOCK
-            if d.decision == DecisionType.TRANSFORM and final == DecisionType.ALLOW:
-                final = DecisionType.TRANSFORM
+            if d.decision == DecisionType.MODIFY and final == DecisionType.ALLOW:
+                final = DecisionType.MODIFY
 
         duration_ms = int((time.monotonic() - start) * 1000)
 

--- a/python/src/vcp/enforcement.py
+++ b/python/src/vcp/enforcement.py
@@ -184,17 +184,22 @@ class AdherenceLevelPlugin(PDPPlugin):
     def priority(self) -> int:
         return 20
 
-    def __init__(self, min_adherence: int = 3) -> None:
+    def __init__(
+        self,
+        min_adherence: int = 3,
+        require_declaration: bool = False,
+    ) -> None:
         if not 0 <= min_adherence <= 5:
             raise ValueError(f"min_adherence must be 0-5, got {min_adherence}")
         self._min_adherence = min_adherence
+        self._require_declaration = require_declaration
 
     def evaluate(self, ctx: EvaluationContext) -> PDPDecision | None:
         bundle = ctx.bundle
         if bundle is None:
             return None
 
-        # Extract adherence level from bundle metadata or manifest
+        # Extract adherence level from metadata kwargs or bundle manifest
         adherence = ctx.metadata.get("adherence_level")
         if adherence is None:
             manifest_meta = getattr(bundle, "manifest", None)
@@ -204,6 +209,12 @@ class AdherenceLevelPlugin(PDPPlugin):
                 )
 
         if adherence is None:
+            if self._require_declaration:
+                return PDPDecision(
+                    decision=DecisionType.BLOCK,
+                    reason="Bundle does not declare an adherence level",
+                    plugin_id=self.plugin_id,
+                )
             return None
 
         try:
@@ -260,7 +271,7 @@ class BundleExpiryPlugin(PDPPlugin):
             return None
 
         now = datetime.now(timezone.utc)
-        if hasattr(exp, "tzinfo") and exp.tzinfo is None:
+        if exp.tzinfo is None:
             exp = exp.replace(tzinfo=timezone.utc)
 
         if now > exp:
@@ -377,7 +388,12 @@ class PDPEnforcer:
                 final = DecisionType.BLOCK
                 break
             if d.decision == DecisionType.ESCALATE:
-                final = DecisionType.BLOCK  # No escalation handler → fail-closed
+                logger.warning(
+                    "Plugin %s requested escalation but no handler is set — "
+                    "promoting to BLOCK (fail-closed)",
+                    d.plugin_id,
+                )
+                final = DecisionType.BLOCK
             if d.decision == DecisionType.TRANSFORM and final == DecisionType.ALLOW:
                 final = DecisionType.TRANSFORM
 

--- a/python/src/vcp/identity/registry.py
+++ b/python/src/vcp/identity/registry.py
@@ -46,7 +46,7 @@ import secrets
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -83,8 +83,8 @@ class RegistryEntry:
     privacy_tier: PrivacyTier
     owner_id: str | None = None  # None for public/pseudonymous
     owner_pubkey: bytes | None = None  # For encrypted metadata
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    updated_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     metadata_encrypted: bytes | None = None  # E(pubkey, metadata)
     metadata_public: dict[str, object] = field(default_factory=dict)
 

--- a/python/tests/unit/api/test_vcp_router.py
+++ b/python/tests/unit/api/test_vcp_router.py
@@ -124,11 +124,12 @@ class TestContextEncodeRequestModel:
             space="home",
             company=["children", "family"],
             occasion="normal",
-            state="happy",
+            cognitive_state="focused:4",
             agency="leader",
         )
         assert model.time == "morning"
         assert model.company == ["children", "family"]
+        assert model.cognitive_state == "focused:4"
 
     def test_minimal_request(self) -> None:
         """Test creating minimal request."""

--- a/python/tests/unit/test_vcp_audit.py
+++ b/python/tests/unit/test_vcp_audit.py
@@ -163,7 +163,7 @@ class TestGDPRPurge:
         assert tombstone["entries_removed"] == 2
         assert "purge_id" in tombstone
         assert "timestamp" in tombstone
-        assert tombstone["scope"] == "in-memory audit entries only"
+        assert tombstone["scope"] == "in-memory audit entries + tracked exported JSON files"
         # Tombstone must NOT contain session_id_hash (GDPR: the hash itself is PII)
         assert "session_id_hash" not in tombstone
         assert len(logger._entries) == 1
@@ -181,6 +181,45 @@ class TestGDPRPurge:
         logger = AuditLogger(level=AuditLevel.STANDARD)
         tombstone = logger.purge_by_session("any")
         assert tombstone["entries_removed"] == 0
+
+    def test_purge_scrubs_exported_json_file(self, tmp_path) -> None:
+        logger = AuditLogger(level=AuditLevel.STANDARD)
+        hash_a = _hash_for_privacy("user-A")
+        hash_b = _hash_for_privacy("user-B")
+        logger._entries.append(_make_entry(session_id_hash=hash_a))
+        logger._entries.append(_make_entry(session_id_hash=hash_b))
+        logger._entries.append(_make_entry(session_id_hash=hash_a))
+
+        export_path = str(tmp_path / "audit_export.json")
+        logger.export_json(export_path)
+
+        # Clear in-memory so we test file-only purge
+        logger._entries.clear()
+        tombstone = logger.purge_by_session("user-A")
+
+        assert tombstone["entries_removed"] == 0  # already cleared
+        assert tombstone["file_entries_removed"] == 2
+        assert export_path in tombstone["files_purged"]
+
+        import json
+        with open(export_path) as f:
+            data = json.load(f)
+        remaining = data["entries"]
+        assert len(remaining) == 1
+        # Remaining entry should be user-B (at STANDARD+, session_id_hash is present)
+        assert remaining[0].get("session_id_hash") == hash_b
+
+    def test_export_json_tracks_path(self, tmp_path) -> None:
+        logger = AuditLogger(level=AuditLevel.STANDARD)
+        p = str(tmp_path / "out.json")
+        logger.export_json(p)
+        assert p in logger._exported_paths
+
+    def test_purge_handles_missing_export_file(self, tmp_path) -> None:
+        logger = AuditLogger(level=AuditLevel.STANDARD)
+        logger._exported_paths.append(str(tmp_path / "gone.json"))
+        tombstone = logger.purge_by_session("user-X")
+        assert tombstone["file_entries_removed"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/unit/test_vcp_audit.py
+++ b/python/tests/unit/test_vcp_audit.py
@@ -164,6 +164,7 @@ class TestGDPRPurge:
         assert "purge_id" in tombstone
         assert "timestamp" in tombstone
         assert tombstone["scope"] == "in-memory audit entries + tracked exported JSON files"
+        assert tombstone["external_sink_results"] == []
         # Tombstone must NOT contain session_id_hash (GDPR: the hash itself is PII)
         assert "session_id_hash" not in tombstone
         assert len(logger._entries) == 1
@@ -220,6 +221,65 @@ class TestGDPRPurge:
         logger._exported_paths.append(str(tmp_path / "gone.json"))
         tombstone = logger.purge_by_session("user-X")
         assert tombstone["file_entries_removed"] == 0
+
+    def test_purge_handler_called_with_hash_and_id(self) -> None:
+        calls = []
+
+        def handler(session_hash: str, purge_id: str) -> dict:
+            calls.append((session_hash, purge_id))
+            return {"redis_keys_deleted": 3}
+
+        logger = AuditLogger(level=AuditLevel.STANDARD)
+        logger.register_purge_handler(handler)
+        logger._entries.append(_make_entry(session_id_hash=_hash_for_privacy("user-A")))
+
+        tombstone = logger.purge_by_session("user-A")
+
+        assert len(calls) == 1
+        assert calls[0][0] == _hash_for_privacy("user-A")
+        assert calls[0][1] == tombstone["purge_id"]
+        assert tombstone["external_sink_results"] == [{"redis_keys_deleted": 3}]
+        assert "1 external sink(s)" in tombstone["scope"]
+
+    def test_purge_handler_exception_does_not_crash(self) -> None:
+        def bad_handler(session_hash: str, purge_id: str) -> dict:
+            raise RuntimeError("redis down")
+
+        logger = AuditLogger(level=AuditLevel.STANDARD)
+        logger.register_purge_handler(bad_handler)
+
+        tombstone = logger.purge_by_session("user-A")
+        assert len(tombstone["external_sink_results"]) == 1
+        assert "error" in tombstone["external_sink_results"][0]
+
+    def test_warns_when_callback_set_without_purge_handler(self, caplog) -> None:
+        import logging as _logging
+
+        captured = []
+        logger = AuditLogger(
+            level=AuditLevel.STANDARD,
+            log_callback=captured.append,
+        )
+        logger._entries.append(_make_entry(session_id_hash=_hash_for_privacy("user-A")))
+
+        with caplog.at_level(_logging.WARNING, logger="vcp.audit"):
+            logger.purge_by_session("user-A")
+
+        assert any("no purge handlers are registered" in r.message for r in caplog.records)
+
+    def test_no_warning_when_purge_handler_registered(self, caplog) -> None:
+        import logging as _logging
+
+        logger = AuditLogger(
+            level=AuditLevel.STANDARD,
+            log_callback=lambda _: None,
+        )
+        logger.register_purge_handler(lambda h, p: {"ok": True})
+
+        with caplog.at_level(_logging.WARNING, logger="vcp.audit"):
+            logger.purge_by_session("user-A")
+
+        assert not any("no purge handlers" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/unit/test_vcp_enforcement.py
+++ b/python/tests/unit/test_vcp_enforcement.py
@@ -292,6 +292,14 @@ class TestAdherenceLevelPlugin:
         with pytest.raises(ValueError):
             AdherenceLevelPlugin(min_adherence=6)
 
+    def test_require_declaration_blocks_when_missing(self) -> None:
+        plugin = AdherenceLevelPlugin(min_adherence=3, require_declaration=True)
+        ctx = EvaluationContext(bundle=_make_bundle(), content="hi")
+        decision = plugin.evaluate(ctx)
+        assert decision is not None
+        assert decision.blocked
+        assert "does not declare" in decision.reason
+
     def test_adherence_from_metadata_kwarg(self) -> None:
         plugin = AdherenceLevelPlugin(min_adherence=3)
         ctx = EvaluationContext(

--- a/python/tests/unit/test_vcp_enforcement.py
+++ b/python/tests/unit/test_vcp_enforcement.py
@@ -28,7 +28,6 @@ from vcp.enforcement import (
 )
 from vcp.types import EnforcementMode, VerificationResult
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/python/tests/unit/test_vcp_enforcement.py
+++ b/python/tests/unit/test_vcp_enforcement.py
@@ -1,0 +1,338 @@
+"""
+Tests for vcp.enforcement — PDP plugin enforcement for VCP bundles.
+
+Verifies:
+    - PDPEnforcer orchestration (priority ordering, fail-closed)
+    - RefusalBoundaryPlugin (bundle verification enforcement)
+    - AdherenceLevelPlugin (minimum adherence level)
+    - BundleExpiryPlugin (expired bundle blocking)
+    - Plugin crash handling (fail-closed by default)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from vcp.enforcement import (
+    AdherenceLevelPlugin,
+    BundleExpiryPlugin,
+    DecisionType,
+    EvaluationContext,
+    PDPDecision,
+    PDPEnforcer,
+    PDPPlugin,
+    RefusalBoundaryPlugin,
+)
+from vcp.types import EnforcementMode, VerificationResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_bundle(
+    expired: bool = False,
+    adherence: int | None = None,
+) -> MagicMock:
+    """Create a minimal mock bundle."""
+    bundle = MagicMock()
+    bundle.manifest.metadata = {}
+    if adherence is not None:
+        bundle.manifest.metadata["adherence_level"] = adherence
+
+    now = datetime.now(timezone.utc)
+    if expired:
+        bundle.manifest.timestamps.exp = now - timedelta(hours=1)
+    else:
+        bundle.manifest.timestamps.exp = now + timedelta(hours=1)
+
+    return bundle
+
+
+class _CrashPlugin(PDPPlugin):
+    """Plugin that always raises."""
+
+    @property
+    def plugin_id(self) -> str:
+        return "crash"
+
+    def evaluate(self, ctx: EvaluationContext) -> PDPDecision | None:
+        raise RuntimeError("boom")
+
+
+class _AllowPlugin(PDPPlugin):
+    """Plugin that always abstains (returns None)."""
+
+    @property
+    def plugin_id(self) -> str:
+        return "allow"
+
+    def evaluate(self, ctx: EvaluationContext) -> PDPDecision | None:
+        return None
+
+
+class _BlockPlugin(PDPPlugin):
+    """Plugin that always blocks."""
+
+    @property
+    def plugin_id(self) -> str:
+        return "block"
+
+    @property
+    def priority(self) -> int:
+        return 50
+
+    def evaluate(self, ctx: EvaluationContext) -> PDPDecision | None:
+        return PDPDecision(
+            decision=DecisionType.BLOCK,
+            reason="always block",
+            plugin_id=self.plugin_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# PDPEnforcer
+# ---------------------------------------------------------------------------
+
+
+class TestPDPEnforcer:
+    def test_no_plugins_allows(self) -> None:
+        enforcer = PDPEnforcer()
+        result = enforcer.evaluate(bundle=_make_bundle(), content="hello")
+        assert result.allowed
+        assert result.final_decision == DecisionType.ALLOW
+        assert result.decisions == []
+
+    def test_block_plugin_blocks(self) -> None:
+        enforcer = PDPEnforcer()
+        enforcer.register(_BlockPlugin())
+        result = enforcer.evaluate(bundle=_make_bundle(), content="hello")
+        assert result.blocked
+        assert len(result.blocking_reasons) == 1
+
+    def test_allow_plugin_allows(self) -> None:
+        enforcer = PDPEnforcer()
+        enforcer.register(_AllowPlugin())
+        result = enforcer.evaluate(bundle=_make_bundle(), content="hello")
+        assert result.allowed
+
+    def test_crash_plugin_fail_closed(self) -> None:
+        enforcer = PDPEnforcer(fail_closed=True)
+        enforcer.register(_CrashPlugin())
+        result = enforcer.evaluate(bundle=_make_bundle(), content="hello")
+        assert result.blocked
+        assert "crashed" in result.blocking_reasons[0]
+
+    def test_crash_plugin_fail_open(self) -> None:
+        enforcer = PDPEnforcer(fail_closed=False)
+        enforcer.register(_CrashPlugin())
+        result = enforcer.evaluate(bundle=_make_bundle(), content="hello")
+        assert result.allowed
+
+    def test_plugins_run_in_priority_order(self) -> None:
+        order: list[str] = []
+
+        class _P1(PDPPlugin):
+            @property
+            def plugin_id(self) -> str:
+                return "p1"
+
+            @property
+            def priority(self) -> int:
+                return 200
+
+            def evaluate(self, ctx: EvaluationContext) -> PDPDecision | None:
+                order.append("p1")
+                return None
+
+        class _P2(PDPPlugin):
+            @property
+            def plugin_id(self) -> str:
+                return "p2"
+
+            @property
+            def priority(self) -> int:
+                return 10
+
+            def evaluate(self, ctx: EvaluationContext) -> PDPDecision | None:
+                order.append("p2")
+                return None
+
+        enforcer = PDPEnforcer()
+        enforcer.register(_P1())
+        enforcer.register(_P2())
+        enforcer.evaluate(bundle=_make_bundle(), content="x")
+        assert order == ["p2", "p1"]
+
+    def test_duration_ms_is_populated(self) -> None:
+        enforcer = PDPEnforcer()
+        result = enforcer.evaluate(bundle=_make_bundle(), content="x")
+        assert isinstance(result.duration_ms, int)
+        assert result.duration_ms >= 0
+
+    def test_metadata_passed_to_context(self) -> None:
+        captured: list[EvaluationContext] = []
+
+        class _Spy(PDPPlugin):
+            @property
+            def plugin_id(self) -> str:
+                return "spy"
+
+            def evaluate(self, ctx: EvaluationContext) -> PDPDecision | None:
+                captured.append(ctx)
+                return None
+
+        enforcer = PDPEnforcer()
+        enforcer.register(_Spy())
+        enforcer.evaluate(
+            bundle=_make_bundle(),
+            content="test",
+            session_id="sess-1",
+            verification_result=VerificationResult.VALID,
+        )
+        assert len(captured) == 1
+        assert captured[0].session_id == "sess-1"
+        assert captured[0].metadata["verification_result"] == VerificationResult.VALID
+
+
+# ---------------------------------------------------------------------------
+# RefusalBoundaryPlugin
+# ---------------------------------------------------------------------------
+
+
+class TestRefusalBoundaryPlugin:
+    def test_no_bundle_fail_closed_blocks(self) -> None:
+        plugin = RefusalBoundaryPlugin(mode=EnforcementMode.FAIL_CLOSED)
+        ctx = EvaluationContext(bundle=None, content="hi")
+        decision = plugin.evaluate(ctx)
+        assert decision is not None
+        assert decision.blocked
+
+    def test_no_bundle_audit_only_allows(self) -> None:
+        plugin = RefusalBoundaryPlugin(mode=EnforcementMode.AUDIT_ONLY)
+        ctx = EvaluationContext(bundle=None, content="hi")
+        assert plugin.evaluate(ctx) is None
+
+    def test_valid_verification_allows(self) -> None:
+        plugin = RefusalBoundaryPlugin()
+        ctx = EvaluationContext(
+            bundle=_make_bundle(),
+            content="hi",
+            metadata={"verification_result": VerificationResult.VALID},
+        )
+        assert plugin.evaluate(ctx) is None
+
+    def test_invalid_verification_fail_closed_blocks(self) -> None:
+        plugin = RefusalBoundaryPlugin(mode=EnforcementMode.FAIL_CLOSED)
+        ctx = EvaluationContext(
+            bundle=_make_bundle(),
+            content="hi",
+            metadata={"verification_result": VerificationResult.EXPIRED},
+        )
+        decision = plugin.evaluate(ctx)
+        assert decision is not None
+        assert decision.blocked
+        assert "EXPIRED" in decision.reason
+
+    def test_invalid_verification_escalate_escalates(self) -> None:
+        plugin = RefusalBoundaryPlugin(mode=EnforcementMode.ESCALATE)
+        ctx = EvaluationContext(
+            bundle=_make_bundle(),
+            content="hi",
+            metadata={"verification_result": VerificationResult.HASH_MISMATCH},
+        )
+        decision = plugin.evaluate(ctx)
+        assert decision is not None
+        assert decision.decision == DecisionType.ESCALATE
+
+
+# ---------------------------------------------------------------------------
+# AdherenceLevelPlugin
+# ---------------------------------------------------------------------------
+
+
+class TestAdherenceLevelPlugin:
+    def test_sufficient_adherence_allows(self) -> None:
+        plugin = AdherenceLevelPlugin(min_adherence=3)
+        ctx = EvaluationContext(
+            bundle=_make_bundle(adherence=4),
+            content="hi",
+        )
+        assert plugin.evaluate(ctx) is None
+
+    def test_insufficient_adherence_blocks(self) -> None:
+        plugin = AdherenceLevelPlugin(min_adherence=3)
+        ctx = EvaluationContext(
+            bundle=_make_bundle(adherence=1),
+            content="hi",
+        )
+        decision = plugin.evaluate(ctx)
+        assert decision is not None
+        assert decision.blocked
+
+    def test_no_adherence_metadata_abstains(self) -> None:
+        plugin = AdherenceLevelPlugin(min_adherence=3)
+        ctx = EvaluationContext(bundle=_make_bundle(), content="hi")
+        assert plugin.evaluate(ctx) is None
+
+    def test_invalid_adherence_blocks(self) -> None:
+        plugin = AdherenceLevelPlugin(min_adherence=3)
+        bundle = _make_bundle()
+        bundle.manifest.metadata["adherence_level"] = "not_a_number"
+        ctx = EvaluationContext(bundle=bundle, content="hi")
+        decision = plugin.evaluate(ctx)
+        assert decision is not None
+        assert decision.blocked
+
+    def test_invalid_min_adherence_raises(self) -> None:
+        with pytest.raises(ValueError):
+            AdherenceLevelPlugin(min_adherence=6)
+
+    def test_adherence_from_metadata_kwarg(self) -> None:
+        plugin = AdherenceLevelPlugin(min_adherence=3)
+        ctx = EvaluationContext(
+            bundle=_make_bundle(),
+            content="hi",
+            metadata={"adherence_level": 2},
+        )
+        decision = plugin.evaluate(ctx)
+        assert decision is not None
+        assert decision.blocked
+
+
+# ---------------------------------------------------------------------------
+# BundleExpiryPlugin
+# ---------------------------------------------------------------------------
+
+
+class TestBundleExpiryPlugin:
+    def test_valid_bundle_allows(self) -> None:
+        plugin = BundleExpiryPlugin()
+        ctx = EvaluationContext(bundle=_make_bundle(expired=False), content="hi")
+        assert plugin.evaluate(ctx) is None
+
+    def test_expired_bundle_blocks(self) -> None:
+        plugin = BundleExpiryPlugin()
+        bundle = MagicMock()
+        bundle.manifest.timestamps.exp = datetime.now(timezone.utc) - timedelta(hours=1)
+        ctx = EvaluationContext(bundle=bundle, content="hi")
+        decision = plugin.evaluate(ctx)
+        assert decision is not None
+        assert decision.blocked
+        assert "expired" in decision.reason.lower()
+
+    def test_no_bundle_abstains(self) -> None:
+        plugin = BundleExpiryPlugin()
+        ctx = EvaluationContext(bundle=None, content="hi")
+        assert plugin.evaluate(ctx) is None
+
+    def test_no_expiry_abstains(self) -> None:
+        plugin = BundleExpiryPlugin()
+        bundle = MagicMock()
+        bundle.manifest.timestamps.exp = None
+        ctx = EvaluationContext(bundle=bundle, content="hi")
+        assert plugin.evaluate(ctx) is None

--- a/python/tests/unit/test_vcp_redis_state.py
+++ b/python/tests/unit/test_vcp_redis_state.py
@@ -10,7 +10,7 @@ Coverage target: redis_state.py 0% -> 80%+
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -130,7 +130,10 @@ class TestRedisStateTracker:
         # Set up existing history
         existing_context = VCPContext(dimensions={Dimension.TIME: ["morning"]})
         mock_redis.get.return_value = json.dumps(
-            [{"timestamp": datetime.utcnow().isoformat(), "context": existing_context.to_json()}]
+            [{
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "context": existing_context.to_json(),
+            }]
         )
 
         # Record new context with different time
@@ -149,7 +152,10 @@ class TestRedisStateTracker:
         # Set up existing history
         existing_context = VCPContext(dimensions={Dimension.TIME: ["morning"]})
         mock_redis.get.return_value = json.dumps(
-            [{"timestamp": datetime.utcnow().isoformat(), "context": existing_context.to_json()}]
+            [{
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "context": existing_context.to_json(),
+            }]
         )
 
         # Record new context with AGENCY change (major dimension)
@@ -166,7 +172,10 @@ class TestRedisStateTracker:
         # Set up existing history
         existing_context = VCPContext(dimensions={Dimension.TIME: ["morning"]})
         mock_redis.get.return_value = json.dumps(
-            [{"timestamp": datetime.utcnow().isoformat(), "context": existing_context.to_json()}]
+            [{
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "context": existing_context.to_json(),
+            }]
         )
 
         # Record context with emergency value
@@ -197,7 +206,7 @@ class TestRedisStateTracker:
         # Create history at max capacity
         history = [
             {
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "context": {"time": ["morning"]},
             }
             for _ in range(100)
@@ -232,7 +241,10 @@ class TestRedisStateTracker:
         # Set up existing history
         existing_context = VCPContext(dimensions={Dimension.TIME: ["morning"]})
         mock_redis.get.return_value = json.dumps(
-            [{"timestamp": datetime.utcnow().isoformat(), "context": existing_context.to_json()}]
+            [{
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "context": existing_context.to_json(),
+            }]
         )
 
         # Record transition
@@ -256,7 +268,10 @@ class TestRedisStateTracker:
         # Set up existing history
         existing_context = VCPContext(dimensions={Dimension.TIME: ["morning"]})
         mock_redis.get.return_value = json.dumps(
-            [{"timestamp": datetime.utcnow().isoformat(), "context": existing_context.to_json()}]
+            [{
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "context": existing_context.to_json(),
+            }]
         )
 
         # Should not raise
@@ -271,7 +286,10 @@ class TestRedisStateTracker:
 
         context_data = {"time": ["morning"], "space": ["home"]}
         mock_redis.get.return_value = json.dumps(
-            [{"timestamp": datetime.utcnow().isoformat(), "context": context_data}]
+            [{
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "context": context_data,
+            }]
         )
 
         current = tracker.current
@@ -290,7 +308,7 @@ class TestRedisStateTracker:
         """Test getting history count."""
         history = [
             {
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "context": {"time": ["morning"]},
             }
             for _ in range(5)
@@ -444,7 +462,10 @@ class TestHybridStateTracker:
 
         context_data = {"time": ["evening"]}
         mock_redis.get.return_value = json.dumps(
-            [{"timestamp": datetime.utcnow().isoformat(), "context": context_data}]
+            [{
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "context": context_data,
+            }]
         )
 
         tracker = HybridStateTracker(
@@ -493,7 +514,7 @@ class TestHybridStateTracker:
 
         history = [
             {
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "context": {"time": ["morning"]},
             }
             for _ in range(10)
@@ -752,7 +773,10 @@ class TestEdgeCases:
 
         existing_context = VCPContext(dimensions={Dimension.TIME: ["morning"]})
         mock_redis.get.return_value = json.dumps(
-            [{"timestamp": datetime.utcnow().isoformat(), "context": existing_context.to_json()}]
+            [{
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "context": existing_context.to_json(),
+            }]
         )
 
         tracker = RedisStateTracker(

--- a/python/tests/vcp/adaptation/test_context.py
+++ b/python/tests/vcp/adaptation/test_context.py
@@ -5,12 +5,11 @@ import pytest
 from vcp.adaptation import (
     ContextEncoder,
     Dimension,
-    PersonalStateDimension,
     PersonalState,
+    PersonalStateDimension,
     SituationalDimension,
     VCPContext,
 )
-
 
 # ────────────────────────────────────────────────────────────────────────────
 # SituationalDimension

--- a/python/tests/vcp/adaptation/test_context.py
+++ b/python/tests/vcp/adaptation/test_context.py
@@ -1,111 +1,239 @@
-"""Tests for VCP/A Context Encoder."""
+"""Tests for VCP/A Context Encoder (VCP v3.2 / VEP-0004)."""
 
 import pytest
 
-from vcp.adaptation import ContextEncoder, Dimension, VCPContext
+from vcp.adaptation import (
+    ContextEncoder,
+    Dimension,
+    PersonalStateDimension,
+    PersonalState,
+    SituationalDimension,
+    VCPContext,
+)
 
 
-class TestDimension:
-    """Test Dimension enum."""
+# ────────────────────────────────────────────────────────────────────────────
+# SituationalDimension
+# ────────────────────────────────────────────────────────────────────────────
+
+class TestSituationalDimension:
+    """Test SituationalDimension enum."""
 
     def test_all_dimensions_have_symbol(self):
-        """All dimensions should have a symbol."""
-        for dim in Dimension:
+        for dim in SituationalDimension:
             assert dim.symbol
             assert isinstance(dim.symbol, str)
 
-    def test_all_dimensions_have_position(self):
-        """All dimensions should have unique positions 1-9."""
-        positions = [dim.position for dim in Dimension]
-        assert sorted(positions) == list(range(1, 10))
+    def test_positions_are_unique_1_through_13(self):
+        """v3.2 defines 13 situational dimensions with unique positions 1-13."""
+        positions = [dim.position for dim in SituationalDimension]
+        assert sorted(positions) == list(range(1, 14))
 
-    def test_all_dimensions_have_values(self):
-        """All dimensions should have value mappings."""
-        for dim in Dimension:
-            assert dim.values
-            assert isinstance(dim.values, dict)
+    def test_vep_0004_dims_are_10_through_13(self):
+        expected = {
+            SituationalDimension.EMBODIMENT,
+            SituationalDimension.PROXIMITY,
+            SituationalDimension.RELATIONSHIP,
+            SituationalDimension.FORMALITY,
+        }
+        vep = {d for d in SituationalDimension if d.is_vep_0004}
+        assert vep == expected
+        assert all(10 <= d.position <= 13 for d in vep)
+
+    def test_system_context_is_position_9(self):
+        """SYSTEM_CONTEXT replaces the deprecated STATE at position 9."""
+        assert SituationalDimension.SYSTEM_CONTEXT.position == 9
+
+    def test_state_is_removed(self):
+        """STATE was removed in v3.1 — it must not exist as a SituationalDimension."""
+        names = {d.name for d in SituationalDimension}
+        assert "STATE" not in names
+
+    def test_relationship_is_free_form(self):
+        assert SituationalDimension.RELATIONSHIP.is_free_form
+        assert not SituationalDimension.TIME.is_free_form
+
+    def test_culture_values_are_communication_styles(self):
+        """CULTURE must encode communication styles, not nationalities (per CSM1 v3.2)."""
+        names = set(SituationalDimension.CULTURE.values.values())
+        # Any nationality leak is a regression.
+        forbidden = {"american", "european", "japanese", "global"}
+        assert not (names & forbidden)
+        # Must include at least the core communication styles.
+        assert {"high_context", "low_context", "formal"} <= names
 
     def test_from_name(self):
-        """from_name should return correct dimension."""
-        assert Dimension.from_name("time") == Dimension.TIME
-        assert Dimension.from_name("TIME") == Dimension.TIME
-        assert Dimension.from_name("Space") == Dimension.SPACE
+        assert SituationalDimension.from_name("time") == SituationalDimension.TIME
+        assert SituationalDimension.from_name("TIME") == SituationalDimension.TIME
+        assert (
+            SituationalDimension.from_name("system_context")
+            == SituationalDimension.SYSTEM_CONTEXT
+        )
+        assert SituationalDimension.from_name("embodiment") == SituationalDimension.EMBODIMENT
 
     def test_from_name_invalid(self):
-        """from_name should raise for invalid name."""
-        with pytest.raises(ValueError, match="Unknown dimension"):
-            Dimension.from_name("invalid")
+        with pytest.raises(ValueError, match="Unknown situational dimension"):
+            SituationalDimension.from_name("invalid")
 
+
+class TestDimensionAlias:
+    """`Dimension` stays around as a backwards-compat alias."""
+
+    def test_dimension_is_situational_alias(self):
+        assert Dimension is SituationalDimension
+
+    def test_dimension_state_attribute_gone(self):
+        """The deprecated STATE dim must not resurface under the alias."""
+        assert not hasattr(Dimension, "STATE")
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# PersonalStateDimension
+# ────────────────────────────────────────────────────────────────────────────
+
+class TestPersonalDimension:
+    """Test PersonalStateDimension enum (R-line)."""
+
+    def test_five_personal_dimensions(self):
+        assert len(list(PersonalStateDimension)) == 5
+
+    def test_positions_are_unique_1_through_5(self):
+        positions = [dim.position for dim in PersonalStateDimension]
+        assert sorted(positions) == [1, 2, 3, 4, 5]
+
+    def test_all_have_symbol(self):
+        for dim in PersonalStateDimension:
+            assert dim.symbol
+
+    def test_from_symbol(self):
+        assert PersonalStateDimension.from_symbol("🧠") == PersonalStateDimension.COGNITIVE_STATE
+        assert PersonalStateDimension.from_symbol("🩺") == PersonalStateDimension.BODY_SIGNALS
+        assert PersonalStateDimension.from_symbol("not-a-symbol") is None
+
+
+class TestPersonalState:
+    """Test PersonalState value type."""
+
+    def test_bare_value(self):
+        ps = PersonalState(value="focused")
+        assert ps.value == "focused"
+        assert ps.intensity is None
+        assert ps.encode() == "focused"
+
+    def test_with_intensity(self):
+        ps = PersonalState(value="calm", intensity=5)
+        assert ps.encode() == "calm:5"
+
+    def test_intensity_must_be_1_through_5(self):
+        with pytest.raises(ValueError):
+            PersonalState(value="x", intensity=0)
+        with pytest.raises(ValueError):
+            PersonalState(value="x", intensity=6)
+
+    def test_decode_with_intensity(self):
+        assert PersonalState.decode("focused:4") == PersonalState("focused", 4)
+
+    def test_decode_without_intensity(self):
+        assert PersonalState.decode("calm") == PersonalState("calm")
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# VCPContext basic shape
+# ────────────────────────────────────────────────────────────────────────────
 
 class TestVCPContext:
     """Test VCPContext class."""
 
     def test_empty_context(self):
-        """Empty context should be falsy."""
         ctx = VCPContext()
         assert not ctx
         assert ctx.encode() == ""
 
     def test_single_dimension(self):
-        """Context with single dimension."""
-        ctx = VCPContext(dimensions={Dimension.TIME: ["🌅"]})
+        ctx = VCPContext(situational={SituationalDimension.TIME: ["🌅"]})
         assert ctx
-        assert ctx.has(Dimension.TIME)
-        assert not ctx.has(Dimension.SPACE)
+        assert ctx.has(SituationalDimension.TIME)
+        assert not ctx.has(SituationalDimension.SPACE)
 
     def test_multiple_dimensions(self):
-        """Context with multiple dimensions."""
         ctx = VCPContext(
-            dimensions={
-                Dimension.TIME: ["🌅"],
-                Dimension.SPACE: ["🏡"],
-                Dimension.COMPANY: ["👶", "👨‍👩‍👧"],
+            situational={
+                SituationalDimension.TIME: ["🌅"],
+                SituationalDimension.SPACE: ["🏡"],
+                SituationalDimension.COMPANY: ["👶", "👨‍👩‍👧"],
             }
         )
-        assert ctx.get(Dimension.TIME) == ["🌅"]
-        assert ctx.get(Dimension.COMPANY) == ["👶", "👨‍👩‍👧"]
+        assert ctx.get(SituationalDimension.TIME) == ["🌅"]
+        assert ctx.get(SituationalDimension.COMPANY) == ["👶", "👨‍👩‍👧"]
 
     def test_get_missing_dimension(self):
-        """get() should return empty list for missing dimension."""
         ctx = VCPContext()
-        assert ctx.get(Dimension.TIME) == []
+        assert ctx.get(SituationalDimension.TIME) == []
 
     def test_set_returns_new_context(self):
-        """set() should return new context."""
         ctx1 = VCPContext()
-        ctx2 = ctx1.set(Dimension.TIME, ["🌅"])
-        assert ctx1.get(Dimension.TIME) == []
-        assert ctx2.get(Dimension.TIME) == ["🌅"]
+        ctx2 = ctx1.set(SituationalDimension.TIME, ["🌅"])
+        assert ctx1.get(SituationalDimension.TIME) == []
+        assert ctx2.get(SituationalDimension.TIME) == ["🌅"]
+
+    def test_set_personal_returns_new_context(self):
+        ctx1 = VCPContext()
+        ctx2 = ctx1.set_personal(PersonalStateDimension.COGNITIVE_STATE, "focused", 4)
+        assert ctx1.get_personal(PersonalStateDimension.COGNITIVE_STATE) is None
+        ps = ctx2.get_personal(PersonalStateDimension.COGNITIVE_STATE)
+        assert ps == PersonalState("focused", 4)
+
+    def test_has_personal(self):
+        ctx = VCPContext(
+            personal={PersonalStateDimension.EMOTIONAL_TONE: PersonalState("calm", 5)}
+        )
+        assert ctx.has(PersonalStateDimension.EMOTIONAL_TONE)
+        assert not ctx.has(PersonalStateDimension.ENERGY_LEVEL)
+
+    def test_dimensions_backcompat_alias(self):
+        """ctx.dimensions is a compatibility alias for ctx.situational."""
+        ctx = VCPContext(situational={SituationalDimension.TIME: ["🌅"]})
+        assert ctx.dimensions is ctx.situational
 
     def test_equality(self):
-        """Context equality comparison."""
-        ctx1 = VCPContext(dimensions={Dimension.TIME: ["🌅"]})
-        ctx2 = VCPContext(dimensions={Dimension.TIME: ["🌅"]})
-        ctx3 = VCPContext(dimensions={Dimension.TIME: ["🌙"]})
-
+        ctx1 = VCPContext(situational={SituationalDimension.TIME: ["🌅"]})
+        ctx2 = VCPContext(situational={SituationalDimension.TIME: ["🌅"]})
+        ctx3 = VCPContext(situational={SituationalDimension.TIME: ["🌙"]})
         assert ctx1 == ctx2
         assert ctx1 != ctx3
 
+    def test_equality_considers_personal_band(self):
+        ctx1 = VCPContext(
+            situational={SituationalDimension.TIME: ["🌅"]},
+            personal={PersonalStateDimension.COGNITIVE_STATE: PersonalState("focused", 4)},
+        )
+        ctx2 = VCPContext(
+            situational={SituationalDimension.TIME: ["🌅"]},
+            personal={PersonalStateDimension.COGNITIVE_STATE: PersonalState("focused", 3)},
+        )
+        assert ctx1 != ctx2
+
     def test_equality_not_implemented(self):
-        """Equality with non-context returns NotImplemented."""
         ctx = VCPContext()
         assert ctx != "not a context"
 
 
+# ────────────────────────────────────────────────────────────────────────────
+# Wire format
+# ────────────────────────────────────────────────────────────────────────────
+
 class TestVCPContextEncoding:
     """Test VCPContext wire format encoding."""
 
-    def test_encode_single(self):
-        """Encode single dimension."""
-        ctx = VCPContext(dimensions={Dimension.TIME: ["🌅"]})
+    def test_encode_single_situational(self):
+        ctx = VCPContext(situational={SituationalDimension.TIME: ["🌅"]})
         assert ctx.encode() == "⏰🌅"
 
-    def test_encode_multiple(self):
-        """Encode multiple dimensions."""
+    def test_encode_multiple_situational(self):
         ctx = VCPContext(
-            dimensions={
-                Dimension.TIME: ["🌅"],
-                Dimension.SPACE: ["🏡"],
+            situational={
+                SituationalDimension.TIME: ["🌅"],
+                SituationalDimension.SPACE: ["🏡"],
             }
         )
         encoded = ctx.encode()
@@ -113,146 +241,303 @@ class TestVCPContextEncoding:
         assert "📍🏡" in encoded
         assert "|" in encoded
 
-    def test_decode_single(self):
-        """Decode single dimension."""
-        ctx = VCPContext.decode("⏰🌅")
-        assert ctx.get(Dimension.TIME) == ["🌅"]
+    def test_encode_personal_separator_is_u2016(self):
+        """Personal-state band is separated from situational by U+2016 (‖)."""
+        ctx = VCPContext(
+            situational={SituationalDimension.TIME: ["🌅"]},
+            personal={PersonalStateDimension.COGNITIVE_STATE: PersonalState("focused", 4)},
+        )
+        encoded = ctx.encode()
+        assert "\u2016" in encoded
+        assert "‖🧠focused:4" in encoded
+
+    def test_encode_personal_without_intensity(self):
+        ctx = VCPContext(
+            personal={PersonalStateDimension.EMOTIONAL_TONE: PersonalState("calm")}
+        )
+        # Situational empty → encoding begins with the ‖ separator.
+        assert ctx.encode() == "\u2016💭calm"
+
+    def test_encode_vep_0004_relationship_is_free_form(self):
+        ctx = VCPContext(
+            situational={SituationalDimension.RELATIONSHIP: ["colleague:professional"]}
+        )
+        assert ctx.encode() == "🪢colleague:professional"
+
+    def test_encode_full_18_dim_example(self):
+        """End-to-end example matching the spec's canonical 18-dim wire string."""
+        ctx = VCPContext(
+            situational={
+                SituationalDimension.TIME: ["🌅"],
+                SituationalDimension.SPACE: ["🏢"],
+                SituationalDimension.COMPANY: ["👔"],
+                SituationalDimension.OCCASION: ["💼"],
+                SituationalDimension.EMBODIMENT: ["✋"],
+                SituationalDimension.PROXIMITY: ["🤏"],
+                SituationalDimension.RELATIONSHIP: ["colleague:professional"],
+                SituationalDimension.FORMALITY: ["💼"],
+            },
+            personal={
+                PersonalStateDimension.COGNITIVE_STATE: PersonalState("focused", 4),
+                PersonalStateDimension.EMOTIONAL_TONE: PersonalState("calm", 5),
+                PersonalStateDimension.ENERGY_LEVEL: PersonalState("rested", 4),
+                PersonalStateDimension.PERCEIVED_URGENCY: PersonalState("unhurried", 2),
+                PersonalStateDimension.BODY_SIGNALS: PersonalState("neutral", 1),
+            },
+        )
+        expected = (
+            "⏰🌅|📍🏢|👥👔|🎭💼|🧍✋|↔️🤏|🪢colleague:professional|🎩💼"
+            "\u2016"
+            "🧠focused:4|💭calm:5|🔋rested:4|⚡unhurried:2|🩺neutral:1"
+        )
+        assert ctx.encode() == expected
 
     def test_decode_empty(self):
-        """Decode empty string."""
         ctx = VCPContext.decode("")
         assert not ctx
 
-    def test_roundtrip(self):
-        """Encode and decode should roundtrip."""
+    def test_decode_single_situational(self):
+        ctx = VCPContext.decode("⏰🌅")
+        assert ctx.get(SituationalDimension.TIME) == ["🌅"]
+
+    def test_decode_personal_band(self):
+        ctx = VCPContext.decode("⏰🌅\u2016🧠focused:4")
+        assert ctx.get(SituationalDimension.TIME) == ["🌅"]
+        ps = ctx.get_personal(PersonalStateDimension.COGNITIVE_STATE)
+        assert ps == PersonalState("focused", 4)
+
+    def test_decode_relationship_raw_string(self):
+        ctx = VCPContext.decode("🪢friend:social")
+        assert ctx.get(SituationalDimension.RELATIONSHIP) == ["friend:social"]
+
+    def test_roundtrip_core(self):
         original = VCPContext(
-            dimensions={
-                Dimension.TIME: ["🌅"],
-                Dimension.SPACE: ["🏡"],
+            situational={
+                SituationalDimension.TIME: ["🌅"],
+                SituationalDimension.SPACE: ["🏡"],
             }
         )
-        encoded = original.encode()
-        decoded = VCPContext.decode(encoded)
+        decoded = VCPContext.decode(original.encode())
+        assert decoded.get(SituationalDimension.TIME) == ["🌅"]
+        assert decoded.get(SituationalDimension.SPACE) == ["🏡"]
 
-        # Note: exact equality may fail due to emoji parsing variations
-        assert decoded.get(Dimension.TIME) == original.get(Dimension.TIME)
-        assert decoded.get(Dimension.SPACE) == original.get(Dimension.SPACE)
+    def test_roundtrip_full_18_dim(self):
+        original = VCPContext(
+            situational={
+                SituationalDimension.TIME: ["🌅"],
+                SituationalDimension.EMBODIMENT: ["✋"],
+                SituationalDimension.PROXIMITY: ["🤏"],
+                SituationalDimension.RELATIONSHIP: ["colleague:professional"],
+                SituationalDimension.FORMALITY: ["💼"],
+            },
+            personal={
+                PersonalStateDimension.COGNITIVE_STATE: PersonalState("focused", 4),
+                PersonalStateDimension.EMOTIONAL_TONE: PersonalState("calm", 5),
+            },
+        )
+        decoded = VCPContext.decode(original.encode())
+        assert decoded == original
 
+
+# ────────────────────────────────────────────────────────────────────────────
+# JSON
+# ────────────────────────────────────────────────────────────────────────────
 
 class TestVCPContextJSON:
     """Test VCPContext JSON serialization."""
 
     def test_to_json_empty(self):
-        """Empty context to JSON."""
         ctx = VCPContext()
         data = ctx.to_json()
-        assert all(v == [] for v in data.values())
+        assert set(data.keys()) == {"situational", "personal"}
+        assert all(v == [] for v in data["situational"].values())
+        assert data["personal"] == {}
 
     def test_to_json_with_values(self):
-        """Context with values to JSON."""
         ctx = VCPContext(
-            dimensions={
-                Dimension.TIME: ["🌅"],
-                Dimension.COMPANY: ["👶", "👨‍👩‍👧"],
-            }
+            situational={
+                SituationalDimension.TIME: ["🌅"],
+                SituationalDimension.COMPANY: ["👶", "👨‍👩‍👧"],
+            },
+            personal={PersonalStateDimension.COGNITIVE_STATE: PersonalState("focused", 4)},
         )
         data = ctx.to_json()
-        assert data["time"] == ["🌅"]
-        assert data["company"] == ["👶", "👨‍👩‍👧"]
-        assert data["space"] == []
+        assert data["situational"]["time"] == ["🌅"]
+        assert data["situational"]["company"] == ["👶", "👨‍👩‍👧"]
+        assert data["situational"]["space"] == []
+        assert data["personal"]["cognitive_state"] == {
+            "value": "focused",
+            "intensity": 4,
+        }
 
-    def test_from_json(self):
-        """Create context from JSON."""
+    def test_from_json_v32_shape(self):
+        data = {
+            "situational": {"time": ["🌅"], "space": ["🏡"]},
+            "personal": {"cognitive_state": {"value": "focused", "intensity": 4}},
+        }
+        ctx = VCPContext.from_json(data)
+        assert ctx.get(SituationalDimension.TIME) == ["🌅"]
+        ps = ctx.get_personal(PersonalStateDimension.COGNITIVE_STATE)
+        assert ps == PersonalState("focused", 4)
+
+    def test_from_json_legacy_flat_shape(self):
+        """Pre-v3.2 flat shape still decodes (situational-only)."""
         data = {"time": ["🌅"], "space": ["🏡"]}
         ctx = VCPContext.from_json(data)
-        assert ctx.get(Dimension.TIME) == ["🌅"]
-        assert ctx.get(Dimension.SPACE) == ["🏡"]
+        assert ctx.get(SituationalDimension.TIME) == ["🌅"]
+        assert ctx.get(SituationalDimension.SPACE) == ["🏡"]
 
     def test_from_json_string_value(self):
-        """from_json should handle single string value."""
-        data = {"time": "🌅"}
+        data = {"situational": {"time": "🌅"}}
         ctx = VCPContext.from_json(data)
-        assert ctx.get(Dimension.TIME) == ["🌅"]
+        assert ctx.get(SituationalDimension.TIME) == ["🌅"]
 
     def test_json_roundtrip(self):
-        """JSON serialization should roundtrip."""
         original = VCPContext(
-            dimensions={
-                Dimension.TIME: ["🌅"],
-                Dimension.COMPANY: ["👶"],
-            }
+            situational={
+                SituationalDimension.TIME: ["🌅"],
+                SituationalDimension.COMPANY: ["👶"],
+            },
+            personal={
+                PersonalStateDimension.EMOTIONAL_TONE: PersonalState("calm", 5),
+            },
         )
-        data = original.to_json()
-        restored = VCPContext.from_json(data)
+        restored = VCPContext.from_json(original.to_json())
         assert original == restored
 
 
+# ────────────────────────────────────────────────────────────────────────────
+# ContextEncoder
+# ────────────────────────────────────────────────────────────────────────────
+
 class TestContextEncoder:
-    """Test ContextEncoder class."""
+    """Test ContextEncoder keyword-argument interface."""
 
     @pytest.fixture
     def encoder(self):
-        """Create encoder instance."""
         return ContextEncoder()
 
     def test_encode_time(self, encoder):
-        """Encode time context."""
         ctx = encoder.encode(time="morning")
-        assert ctx.get(Dimension.TIME) == ["🌅"]
+        assert ctx.get(SituationalDimension.TIME) == ["🌅"]
 
     def test_encode_space(self, encoder):
-        """Encode space context."""
         ctx = encoder.encode(space="home")
-        assert ctx.get(Dimension.SPACE) == ["🏡"]
+        assert ctx.get(SituationalDimension.SPACE) == ["🏡"]
 
     def test_encode_company_list(self, encoder):
-        """Encode company as list."""
         ctx = encoder.encode(company=["children", "family"])
-        values = ctx.get(Dimension.COMPANY)
+        values = ctx.get(SituationalDimension.COMPANY)
         assert "👶" in values
         assert "👨‍👩‍👧" in values
 
     def test_encode_company_string(self, encoder):
-        """Encode company as string."""
         ctx = encoder.encode(company="alone")
-        assert ctx.get(Dimension.COMPANY) == ["👤"]
+        assert ctx.get(SituationalDimension.COMPANY) == ["👤"]
 
     def test_encode_multiple(self, encoder):
-        """Encode multiple dimensions."""
         ctx = encoder.encode(
             time="morning",
             space="home",
             company=["children"],
             occasion="normal",
         )
-        assert ctx.has(Dimension.TIME)
-        assert ctx.has(Dimension.SPACE)
-        assert ctx.has(Dimension.COMPANY)
-        assert ctx.has(Dimension.OCCASION)
+        assert ctx.has(SituationalDimension.TIME)
+        assert ctx.has(SituationalDimension.SPACE)
+        assert ctx.has(SituationalDimension.COMPANY)
+        assert ctx.has(SituationalDimension.OCCASION)
 
     def test_encode_invalid_value(self, encoder):
-        """Unknown values should not be added."""
         ctx = encoder.encode(time="invalid_time")
-        assert not ctx.has(Dimension.TIME)
+        assert not ctx.has(SituationalDimension.TIME)
 
     def test_encode_empty(self, encoder):
-        """Encoding with no args returns empty context."""
         ctx = encoder.encode()
         assert not ctx
 
-    def test_encode_state(self, encoder):
-        """Encode mental state."""
-        ctx = encoder.encode(state="happy")
-        assert ctx.get(Dimension.STATE) == ["😊"]
-
     def test_encode_agency(self, encoder):
-        """Encode agency level."""
         ctx = encoder.encode(agency="leader")
-        assert ctx.get(Dimension.AGENCY) == ["👑"]
+        assert ctx.get(SituationalDimension.AGENCY) == ["👑"]
 
     def test_encode_constraints_list(self, encoder):
-        """Encode constraints as list."""
         ctx = encoder.encode(constraints=["legal", "time"])
-        values = ctx.get(Dimension.CONSTRAINTS)
+        values = ctx.get(SituationalDimension.CONSTRAINTS)
         assert "⚖️" in values
         assert "⏱️" in values
+
+    # ── VEP-0004 ────────────────────────────────────────────────────────
+    def test_encode_embodiment(self, encoder):
+        ctx = encoder.encode(embodiment="manipulating")
+        assert ctx.get(SituationalDimension.EMBODIMENT) == ["✋"]
+
+    def test_encode_proximity(self, encoder):
+        ctx = encoder.encode(proximity="close")
+        assert ctx.get(SituationalDimension.PROXIMITY) == ["🤏"]
+
+    def test_encode_relationship_is_passthrough(self, encoder):
+        ctx = encoder.encode(relationship="colleague:professional")
+        assert ctx.get(SituationalDimension.RELATIONSHIP) == ["colleague:professional"]
+
+    def test_encode_formality(self, encoder):
+        ctx = encoder.encode(formality="professional")
+        assert ctx.get(SituationalDimension.FORMALITY) == ["💼"]
+
+    def test_encode_system_context(self, encoder):
+        ctx = encoder.encode(system_context="online")
+        assert ctx.get(SituationalDimension.SYSTEM_CONTEXT) == ["🟢"]
+
+    def test_encode_culture_communication_style(self, encoder):
+        """CULTURE must accept communication-style values, not nationalities."""
+        ctx = encoder.encode(culture="high_context")
+        assert ctx.get(SituationalDimension.CULTURE) == ["🔇"]
+
+    def test_encode_culture_legacy_nationality_is_rejected(self, encoder):
+        """Legacy nationality values must no longer resolve (regression guard)."""
+        ctx = encoder.encode(culture="american")
+        assert not ctx.has(SituationalDimension.CULTURE)
+
+    # ── Personal state ──────────────────────────────────────────────────
+    def test_encode_personal_state_as_string(self, encoder):
+        ctx = encoder.encode(cognitive_state="focused")
+        ps = ctx.get_personal(PersonalStateDimension.COGNITIVE_STATE)
+        assert ps == PersonalState("focused")
+
+    def test_encode_personal_state_with_intensity_tuple(self, encoder):
+        ctx = encoder.encode(cognitive_state=("focused", 4))
+        ps = ctx.get_personal(PersonalStateDimension.COGNITIVE_STATE)
+        assert ps == PersonalState("focused", 4)
+
+    def test_encode_personal_state_with_inline_intensity(self, encoder):
+        ctx = encoder.encode(emotional_tone="calm:5")
+        ps = ctx.get_personal(PersonalStateDimension.EMOTIONAL_TONE)
+        assert ps == PersonalState("calm", 5)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Conformance classification
+# ────────────────────────────────────────────────────────────────────────────
+
+class TestConformanceLevel:
+    def test_minimal(self):
+        ctx = VCPContext(situational={SituationalDimension.TIME: ["🌅"]})
+        assert ctx.conformance_level() == "VCP-Minimal"
+
+    def test_standard(self):
+        ctx = VCPContext(
+            situational={SituationalDimension.TIME: ["🌅"]},
+            personal={PersonalStateDimension.COGNITIVE_STATE: PersonalState("focused", 4)},
+        )
+        assert ctx.conformance_level() == "VCP-Standard"
+
+    def test_extended(self):
+        ctx = VCPContext(
+            situational={SituationalDimension.EMBODIMENT: ["✋"]},
+        )
+        assert ctx.conformance_level() == "VCP-Extended"
+
+    def test_extended_takes_precedence_over_standard(self):
+        ctx = VCPContext(
+            situational={SituationalDimension.FORMALITY: ["💼"]},
+            personal={PersonalStateDimension.COGNITIVE_STATE: PersonalState("focused")},
+        )
+        assert ctx.conformance_level() == "VCP-Extended"

--- a/python/tests/vcp/adaptation/test_state.py
+++ b/python/tests/vcp/adaptation/test_state.py
@@ -130,8 +130,8 @@ class TestStateTracker:
 
     def test_multiple_changes_is_major(self, tracker, encoder):
         """Three or more dimension changes should be MAJOR."""
-        ctx1 = encoder.encode(time="morning", space="home", state="happy")
-        ctx2 = encoder.encode(time="evening", space="office", state="anxious")
+        ctx1 = encoder.encode(time="morning", space="home", culture="casual")
+        ctx2 = encoder.encode(time="evening", space="office", culture="formal")
         tracker.record(ctx1)
         transition = tracker.record(ctx2)
         assert transition.severity == TransitionSeverity.MAJOR
@@ -287,7 +287,7 @@ class TestFindTransitions:
         tracker.record(encoder.encode(time="evening"))
 
         # Record a major change (3+ dimensions)
-        tracker.record(encoder.encode(time="night", space="office", state="tired"))
+        tracker.record(encoder.encode(time="night", space="office", culture="formal"))
 
         minor = tracker.find_transitions(TransitionSeverity.MINOR)
         major = tracker.find_transitions(TransitionSeverity.MAJOR)

--- a/python/tests/vcp/test_vectors.py
+++ b/python/tests/vcp/test_vectors.py
@@ -5,7 +5,7 @@ These test vectors can be used to verify implementations of VCP v2.0.
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 # ==============================================================================
 # TEST VECTOR 1: Valid Minimal Bundle
@@ -533,7 +533,7 @@ def export_test_vectors(path: str = "vcp_test_vectors.json") -> None:
     # Convert to JSON-serializable format
     vectors = {
         "version": "1.0",
-        "generated": datetime.utcnow().isoformat() + "Z",
+        "generated": datetime.now(timezone.utc).isoformat() + "Z",
         "vectors": ALL_TEST_VECTORS,
     }
     with open(path, "w", encoding="utf-8") as f:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -107,9 +107,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cast"
@@ -134,9 +134,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -156,7 +156,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -209,15 +209,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -363,26 +363,25 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -416,7 +415,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -432,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -474,12 +473,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -492,9 +491,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -516,9 +515,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -569,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -587,15 +586,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -659,7 +652,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -673,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "regex"
@@ -702,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc_version"
@@ -732,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -877,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -892,15 +885,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -925,7 +918,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcp-cli"
-version = "4.0.0"
+version = "4.2.0"
 dependencies = [
  "clap",
  "serde_json",
@@ -934,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "vcp-core"
-version = "4.0.0"
+version = "4.2.0"
 dependencies = [
  "base64",
  "chrono",
@@ -951,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "vcp-wasm"
-version = "4.0.0"
+version = "4.2.0"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
@@ -985,11 +978,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -998,7 +991,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1214,6 +1207,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["vcp-core", "vcp-wasm", "vcp-cli"]
 
 [workspace.package]
-version = "4.0.0"
+version = "4.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/creed-space/vcp-sdk"

--- a/rust/vcp-core/src/context.rs
+++ b/rust/vcp-core/src/context.rs
@@ -1,4 +1,4 @@
-//! Context wire format: combined situational + personal encoding.
+//! Context wire format: combined situational + personal encoding (VCP v3.2).
 //!
 //! The full wire format joins the situational and personal halves with
 //! a double-pipe separator (`\u{2016}`):
@@ -11,6 +11,14 @@
 //! ```text
 //! \u{23F0}\u{1F305}|\u{1F4CD}\u{1F3E1}\u{2016}\u{1F9E0}focused:4|\u{1F4AD}calm:3
 //! ```
+//!
+//! ## Conformance levels (VCP v3.2)
+//!
+//! | level          | shape                                                 |
+//! |----------------|-------------------------------------------------------|
+//! | VCP-Minimal    | situational only, core 9 dims (positions 1-9)         |
+//! | VCP-Standard   | Minimal + any personal-state dim                      |
+//! | VCP-Extended   | Standard (or Minimal) + any VEP-0004 dim (pos 10-13)  |
 
 use serde::{Deserialize, Serialize};
 
@@ -18,14 +26,48 @@ use crate::error::VcpResult;
 use crate::personal::PersonalState;
 use crate::situational::SituationalContext;
 
+/// VCP v3.2 conformance classification for a [`FullContext`].
+///
+/// Serializes as the canonical labels `VCP-Minimal`, `VCP-Standard`,
+/// or `VCP-Extended` — matching the schema at
+/// `schemas/vcp-adaptation-context.schema.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ConformanceLevel {
+    /// Situational only, core 9 dims (positions 1-9). No personal,
+    /// no VEP-0004.
+    #[serde(rename = "VCP-Minimal")]
+    Minimal,
+    /// Core 9 situational + at least one personal-state dim.
+    #[serde(rename = "VCP-Standard")]
+    Standard,
+    /// Any VEP-0004 dimension present (positions 10-13). Takes
+    /// precedence over Standard.
+    #[serde(rename = "VCP-Extended")]
+    Extended,
+}
+
+impl ConformanceLevel {
+    /// Canonical kebab-case label: `VCP-Minimal` / `VCP-Standard` / `VCP-Extended`.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Minimal => "VCP-Minimal",
+            Self::Standard => "VCP-Standard",
+            Self::Extended => "VCP-Extended",
+        }
+    }
+}
+
 /// The separator between the situational and personal halves of the
 /// full context wire format.
 pub const WIRE_SEPARATOR: char = '\u{2016}'; // double vertical line
 
-/// Full VCP context combining situational and personal state.
+/// Full VCP context combining situational and personal state (VCP v3.2).
+///
+/// Situational carries 13 dimensions (9 core + 4 VEP-0004).
+/// Personal carries 5 dimensions.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FullContext {
-    /// Situational context (9 dimensions).
+    /// Situational context (13 dimensions, VCP v3.2).
     pub situational: SituationalContext,
     /// Personal state (5 dimensions).
     pub personal: PersonalState,
@@ -43,6 +85,21 @@ impl FullContext {
     /// Returns `true` if either half has data.
     pub fn has_any(&self) -> bool {
         self.situational.has_any() || self.personal.has_any()
+    }
+
+    /// Classify this context against the VCP v3.2 conformance levels.
+    ///
+    /// Extended (any VEP-0004 dim) wins over Standard. A context with no
+    /// personal data and no VEP-0004 dims is classified as Minimal — even
+    /// if it is empty.
+    pub fn conformance_level(&self) -> ConformanceLevel {
+        if self.situational.has_vep_0004() {
+            ConformanceLevel::Extended
+        } else if self.personal.has_any() {
+            ConformanceLevel::Standard
+        } else {
+            ConformanceLevel::Minimal
+        }
     }
 
     /// Encode to the full wire format.
@@ -182,5 +239,74 @@ mod tests {
         let json = serde_json::to_string(&ctx).unwrap();
         let parsed: FullContext = serde_json::from_str(&json).unwrap();
         assert_eq!(ctx, parsed);
+    }
+
+    // ── VEP-0004 / v3.2 ─────────────────────────────────────
+
+    #[test]
+    fn full_eighteen_dim_roundtrip() {
+        let mut ctx = FullContext::default();
+        // Situational core
+        ctx.situational.time = Some(vec!["\u{1F305}".to_string()]);
+        ctx.situational.space = Some(vec!["\u{1F3E2}".to_string()]);
+        ctx.situational.company = Some(vec!["\u{1F454}".to_string()]);
+        ctx.situational.occasion = Some(vec!["\u{1F4BC}".to_string()]);
+        // VEP-0004
+        ctx.situational.embodiment = Some(vec!["\u{270B}".to_string()]);
+        ctx.situational.proximity = Some(vec!["\u{1F90F}".to_string()]);
+        ctx.situational.relationship = Some(vec!["colleague:professional".to_string()]);
+        ctx.situational.formality = Some(vec!["\u{1F4BC}".to_string()]);
+        // Personal
+        ctx.personal.cognitive = Some(PersonalDimension::new("focused", 4).unwrap());
+        ctx.personal.emotional = Some(PersonalDimension::new("calm", 5).unwrap());
+
+        let wire = ctx.to_wire();
+        assert!(wire.contains(WIRE_SEPARATOR));
+        assert!(wire.contains("\u{1FAA2}colleague:professional"));
+
+        let parsed = FullContext::from_wire(&wire).unwrap();
+        assert_eq!(
+            parsed.situational.relationship.as_deref(),
+            Some(&["colleague:professional".to_string()][..])
+        );
+        assert_eq!(parsed.personal.cognitive.as_ref().unwrap().value, "focused");
+        assert_eq!(parsed.personal.emotional.as_ref().unwrap().intensity, 5);
+    }
+
+    #[test]
+    fn conformance_minimal_empty() {
+        let ctx = FullContext::default();
+        assert_eq!(ctx.conformance_level(), ConformanceLevel::Minimal);
+        assert_eq!(ctx.conformance_level().label(), "VCP-Minimal");
+    }
+
+    #[test]
+    fn conformance_minimal_core_only() {
+        let mut ctx = FullContext::default();
+        ctx.situational.time = Some(vec!["\u{1F305}".to_string()]);
+        assert_eq!(ctx.conformance_level(), ConformanceLevel::Minimal);
+    }
+
+    #[test]
+    fn conformance_standard_with_personal() {
+        let mut ctx = FullContext::default();
+        ctx.situational.time = Some(vec!["\u{1F305}".to_string()]);
+        ctx.personal.cognitive = Some(PersonalDimension::new("focused", 4).unwrap());
+        assert_eq!(ctx.conformance_level(), ConformanceLevel::Standard);
+    }
+
+    #[test]
+    fn conformance_extended_with_vep_0004() {
+        let mut ctx = FullContext::default();
+        ctx.situational.embodiment = Some(vec!["\u{270B}".to_string()]);
+        assert_eq!(ctx.conformance_level(), ConformanceLevel::Extended);
+    }
+
+    #[test]
+    fn conformance_extended_wins_over_standard() {
+        let mut ctx = FullContext::default();
+        ctx.situational.formality = Some(vec!["\u{1F4BC}".to_string()]);
+        ctx.personal.cognitive = Some(PersonalDimension::new("focused", 4).unwrap());
+        assert_eq!(ctx.conformance_level(), ConformanceLevel::Extended);
     }
 }

--- a/rust/vcp-core/src/hooks.rs
+++ b/rust/vcp-core/src/hooks.rs
@@ -301,7 +301,7 @@ impl HookRegistry {
 
                 hooks.push(hook);
                 // Sort descending by priority (higher runs first).
-                hooks.sort_by_key(|b| std::cmp::Reverse(b.priority));
+                hooks.sort_by_key(|h| std::cmp::Reverse(h.priority));
             }
             HookScope::Session => {
                 let sid = session_id.ok_or_else(|| {
@@ -320,7 +320,7 @@ impl HookRegistry {
                 }
 
                 hooks.push(hook);
-                hooks.sort_by_key(|b| std::cmp::Reverse(b.priority));
+                hooks.sort_by_key(|h| std::cmp::Reverse(h.priority));
             }
         }
 

--- a/rust/vcp-core/src/lib.rs
+++ b/rust/vcp-core/src/lib.rs
@@ -66,7 +66,7 @@ pub mod negotiation;
 pub mod types;
 
 // Re-export commonly used types at crate root.
-pub use context::FullContext;
+pub use context::{ConformanceLevel, FullContext};
 pub use csm1::{Csm1Code, Csm1Token, Persona, Scope};
 pub use error::{VcpError, VcpResult};
 pub use hooks::{
@@ -76,7 +76,7 @@ pub use hooks::{
 pub use identity::VcpToken;
 pub use personal::{PersonalDimension, PersonalState};
 pub use revocation::{RevocationChecker, RevocationStatus};
-pub use situational::SituationalContext;
+pub use situational::{SituationalContext, SituationalDimension};
 pub use transport::{
     compute_content_hash, sign_manifest, verify_content_hash, verify_manifest_signature,
 };

--- a/rust/vcp-core/src/situational.rs
+++ b/rust/vcp-core/src/situational.rs
@@ -1,9 +1,31 @@
-//! Situational context dimensions (VCP v3.1 Layer 2).
+//! Situational context dimensions (VCP v3.2 Layer 2).
 //!
-//! Nine categorical dimensions describe the user's current situation
+//! Thirteen categorical dimensions describe the user's current situation
 //! using emoji-keyed tag arrays in a compact wire format.
 //!
-//! Wire format example: `\u{23F0}\u{1F305}|\u{1F4CD}\u{1F3E1}|\u{1F465}\u{1F454}`
+//! **VCP v3.2 (incl. VEP-0004) dimension map**
+//!
+//! | # | dim            | symbol     | notes                              |
+//! |---|----------------|------------|------------------------------------|
+//! | 1 | time           | ⏰          |                                    |
+//! | 2 | space          | 📍          |                                    |
+//! | 3 | company        | 👥          |                                    |
+//! | 4 | culture        | 🌍          | communication styles, NOT nations |
+//! | 5 | occasion       | 🎭          |                                    |
+//! | 6 | environment    | 🌡️ (VS16)  |                                    |
+//! | 7 | agency         | 🔷          |                                    |
+//! | 8 | constraints    | 🔶          |                                    |
+//! | 9 | system_context | 📡          | replaces deprecated STATE (v3.0)   |
+//! |10 | embodiment     | 🧍          | VEP-0004                           |
+//! |11 | proximity      | ↔️ (VS16)  | VEP-0004                           |
+//! |12 | relationship   | 🪢          | VEP-0004, free-form `{tie}:{fn}`  |
+//! |13 | formality      | 🎩          | VEP-0004                           |
+//!
+//! Wire format example (core-only):
+//! `⏰🌅|📍🏡|👥👶`
+//!
+//! Wire format example (full 13-dim + VEP-0004):
+//! `⏰🌅|📍🏢|👥👔|🎭💼|🧍✋|↔️🤏|🪢colleague:professional|🎩💼`
 
 use std::fmt;
 
@@ -11,7 +33,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{VcpError, VcpResult};
 
-/// The nine situational context dimensions.
+/// The thirteen situational context dimensions (VCP v3.2, incl. VEP-0004).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SituationalDimension {
@@ -24,33 +46,87 @@ pub enum SituationalDimension {
     Agency,
     Constraints,
     SystemContext,
+    // VEP-0004 dimensions (positions 10-13)
+    Embodiment,
+    Proximity,
+    Relationship,
+    Formality,
 }
 
 impl SituationalDimension {
     /// Emoji symbol used as the wire-format prefix.
     pub fn symbol(self) -> &'static str {
         match self {
-            Self::Time => "\u{23F0}",                 // alarm clock
-            Self::Space => "\u{1F4CD}",               // round pushpin
-            Self::Company => "\u{1F465}",             // busts in silhouette
-            Self::Culture => "\u{1F30D}",             // globe showing Europe-Africa
-            Self::Occasion => "\u{1F3AD}",            // performing arts
-            Self::Environment => "\u{1F321}\u{FE0F}", // thermometer
-            Self::Agency => "\u{1F537}",              // large blue diamond
-            Self::Constraints => "\u{1F536}",         // large orange diamond
-            Self::SystemContext => "\u{1F4E1}",       // satellite antenna
+            Self::Time => "\u{23F0}",                 // ⏰ alarm clock
+            Self::Space => "\u{1F4CD}",               // 📍 round pushpin
+            Self::Company => "\u{1F465}",             // 👥 busts in silhouette
+            Self::Culture => "\u{1F30D}",             // 🌍 globe Europe-Africa
+            Self::Occasion => "\u{1F3AD}",            // 🎭 performing arts
+            Self::Environment => "\u{1F321}\u{FE0F}", // 🌡️ thermometer (+ VS16)
+            Self::Agency => "\u{1F537}",              // 🔷 large blue diamond
+            Self::Constraints => "\u{1F536}",         // 🔶 large orange diamond
+            Self::SystemContext => "\u{1F4E1}",       // 📡 satellite antenna
+            // VEP-0004
+            Self::Embodiment => "\u{1F9CD}",          // 🧍 standing person
+            Self::Proximity => "\u{2194}\u{FE0F}",    // ↔️ left-right arrow (+ VS16)
+            Self::Relationship => "\u{1FAA2}",        // 🪢 knot
+            Self::Formality => "\u{1F3A9}",           // 🎩 top hat
         }
+    }
+
+    /// Canonical position (1-13) of this dimension in the wire format.
+    pub fn position(self) -> u8 {
+        match self {
+            Self::Time => 1,
+            Self::Space => 2,
+            Self::Company => 3,
+            Self::Culture => 4,
+            Self::Occasion => 5,
+            Self::Environment => 6,
+            Self::Agency => 7,
+            Self::Constraints => 8,
+            Self::SystemContext => 9,
+            Self::Embodiment => 10,
+            Self::Proximity => 11,
+            Self::Relationship => 12,
+            Self::Formality => 13,
+        }
+    }
+
+    /// `true` if this dimension was introduced by VEP-0004 (positions 10-13).
+    pub fn is_vep_0004(self) -> bool {
+        matches!(
+            self,
+            Self::Embodiment | Self::Proximity | Self::Relationship | Self::Formality
+        )
+    }
+
+    /// `true` if this dimension carries free-form string values
+    /// rather than an emoji tag vocabulary.
+    ///
+    /// Currently only [`Self::Relationship`] is free-form: its value
+    /// is a compound string of form `{tie}:{function}`
+    /// (e.g. `colleague:professional`).
+    pub fn is_free_form(self) -> bool {
+        matches!(self, Self::Relationship)
     }
 
     /// Parse from the emoji symbol prefix.
     pub fn from_symbol(s: &str) -> Option<Self> {
-        // Check two-codepoint variant first (thermometer + VS16).
-        if s.starts_with("\u{1F321}\u{FE0F}") || s == "\u{1F321}\u{FE0F}" {
+        // Multi-codepoint symbols first.
+        if s == "\u{1F321}\u{FE0F}" || s.starts_with("\u{1F321}\u{FE0F}") {
             return Some(Self::Environment);
         }
-        // Also accept bare thermometer without variation selector.
-        if s.starts_with("\u{1F321}") || s == "\u{1F321}" {
+        if s == "\u{1F321}" || s.starts_with("\u{1F321}") {
+            // bare thermometer without VS16
             return Some(Self::Environment);
+        }
+        if s == "\u{2194}\u{FE0F}" || s.starts_with("\u{2194}\u{FE0F}") {
+            return Some(Self::Proximity);
+        }
+        if s == "\u{2194}" || s.starts_with("\u{2194}") {
+            // bare arrow without VS16
+            return Some(Self::Proximity);
         }
         match s {
             "\u{23F0}" => Some(Self::Time),
@@ -61,11 +137,14 @@ impl SituationalDimension {
             "\u{1F537}" => Some(Self::Agency),
             "\u{1F536}" => Some(Self::Constraints),
             "\u{1F4E1}" => Some(Self::SystemContext),
+            "\u{1F9CD}" => Some(Self::Embodiment),
+            "\u{1FAA2}" => Some(Self::Relationship),
+            "\u{1F3A9}" => Some(Self::Formality),
             _ => None,
         }
     }
 
-    /// All nine dimensions in canonical order.
+    /// All thirteen dimensions in canonical position order (1..=13).
     pub fn all() -> &'static [SituationalDimension] {
         &[
             Self::Time,
@@ -77,6 +156,10 @@ impl SituationalDimension {
             Self::Agency,
             Self::Constraints,
             Self::SystemContext,
+            Self::Embodiment,
+            Self::Proximity,
+            Self::Relationship,
+            Self::Formality,
         ]
     }
 }
@@ -93,14 +176,21 @@ impl fmt::Display for SituationalDimension {
             Self::Agency => "agency",
             Self::Constraints => "constraints",
             Self::SystemContext => "system_context",
+            Self::Embodiment => "embodiment",
+            Self::Proximity => "proximity",
+            Self::Relationship => "relationship",
+            Self::Formality => "formality",
         };
         f.write_str(label)
     }
 }
 
-/// The complete set of situational context tags.
+/// The complete set of situational context tags (VCP v3.2, 13 dims).
 ///
-/// Each dimension maps to an optional list of tags (emoji values in wire format).
+/// Each dimension maps to an optional list of tag strings.
+/// For the standard dimensions, tags are emoji values from the
+/// dimension's vocabulary. For [`SituationalDimension::Relationship`],
+/// tags are free-form compound strings of form `{tie}:{function}`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SituationalContext {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -121,6 +211,15 @@ pub struct SituationalContext {
     pub constraints: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_context: Option<Vec<String>>,
+    // VEP-0004 dims
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub embodiment: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proximity: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relationship: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub formality: Option<Vec<String>>,
 }
 
 impl SituationalContext {
@@ -135,16 +234,29 @@ impl SituationalContext {
             || self.agency.is_some()
             || self.constraints.is_some()
             || self.system_context.is_some()
+            || self.embodiment.is_some()
+            || self.proximity.is_some()
+            || self.relationship.is_some()
+            || self.formality.is_some()
+    }
+
+    /// Returns `true` if any VEP-0004 dimension (positions 10-13) has tags.
+    pub fn has_vep_0004(&self) -> bool {
+        self.embodiment.is_some()
+            || self.proximity.is_some()
+            || self.relationship.is_some()
+            || self.formality.is_some()
     }
 
     /// Encode to wire format.
     ///
     /// Each dimension is encoded as `<symbol><tag1><tag2>...` and
-    /// dimensions are separated by `|`.
+    /// dimensions are separated by `|`. Dimensions are emitted in
+    /// canonical position order (1..=13).
     pub fn to_wire(&self) -> String {
         let mut parts = Vec::new();
 
-        let dims: [(SituationalDimension, &Option<Vec<String>>); 9] = [
+        let dims: [(SituationalDimension, &Option<Vec<String>>); 13] = [
             (SituationalDimension::Time, &self.time),
             (SituationalDimension::Space, &self.space),
             (SituationalDimension::Company, &self.company),
@@ -154,6 +266,10 @@ impl SituationalContext {
             (SituationalDimension::Agency, &self.agency),
             (SituationalDimension::Constraints, &self.constraints),
             (SituationalDimension::SystemContext, &self.system_context),
+            (SituationalDimension::Embodiment, &self.embodiment),
+            (SituationalDimension::Proximity, &self.proximity),
+            (SituationalDimension::Relationship, &self.relationship),
+            (SituationalDimension::Formality, &self.formality),
         ];
 
         for (dim, tags_opt) in &dims {
@@ -196,10 +312,10 @@ impl SituationalContext {
             let tags = if rest.is_empty() {
                 Vec::new()
             } else {
-                // Tags are the remaining content. They are typically emoji
-                // characters but we treat them as opaque strings. Each
-                // "word" is a separate tag when space-separated, or
-                // the whole remainder is one tag.
+                // Tags are the remaining content. Relationship values
+                // are free-form `{tie}:{function}` strings and must
+                // be kept intact. Other dimensions' remainders are
+                // treated as a single opaque tag.
                 vec![rest.to_string()]
             };
 
@@ -213,6 +329,10 @@ impl SituationalContext {
                 SituationalDimension::Agency => ctx.agency = Some(tags),
                 SituationalDimension::Constraints => ctx.constraints = Some(tags),
                 SituationalDimension::SystemContext => ctx.system_context = Some(tags),
+                SituationalDimension::Embodiment => ctx.embodiment = Some(tags),
+                SituationalDimension::Proximity => ctx.proximity = Some(tags),
+                SituationalDimension::Relationship => ctx.relationship = Some(tags),
+                SituationalDimension::Formality => ctx.formality = Some(tags),
             }
         }
 
@@ -231,6 +351,10 @@ impl SituationalContext {
             SituationalDimension::Agency => self.agency.as_ref(),
             SituationalDimension::Constraints => self.constraints.as_ref(),
             SituationalDimension::SystemContext => self.system_context.as_ref(),
+            SituationalDimension::Embodiment => self.embodiment.as_ref(),
+            SituationalDimension::Proximity => self.proximity.as_ref(),
+            SituationalDimension::Relationship => self.relationship.as_ref(),
+            SituationalDimension::Formality => self.formality.as_ref(),
         }
     }
 
@@ -246,6 +370,10 @@ impl SituationalContext {
             SituationalDimension::Agency => self.agency = Some(tags),
             SituationalDimension::Constraints => self.constraints = Some(tags),
             SituationalDimension::SystemContext => self.system_context = Some(tags),
+            SituationalDimension::Embodiment => self.embodiment = Some(tags),
+            SituationalDimension::Proximity => self.proximity = Some(tags),
+            SituationalDimension::Relationship => self.relationship = Some(tags),
+            SituationalDimension::Formality => self.formality = Some(tags),
         }
     }
 }
@@ -258,10 +386,30 @@ impl fmt::Display for SituationalContext {
 
 /// Split the leading dimension symbol from a wire-format segment.
 ///
-/// Environment uses a two-codepoint emoji (\u{1F321}\u{FE0F}), so we
-/// must check for it before single-codepoint symbols.
+/// Environment uses a two-codepoint emoji (`🌡️` = U+1F321 U+FE0F), and
+/// Proximity uses a two-codepoint emoji (`↔️` = U+2194 U+FE0F), so
+/// these must be checked before their single-codepoint base forms.
 fn split_situational_symbol(s: &str) -> VcpResult<(SituationalDimension, &str)> {
-    // Known single-codepoint symbols in descending byte-length order.
+    // Two-codepoint (VS16) symbols — check first.
+    let env_sym = "\u{1F321}\u{FE0F}";
+    if let Some(rest) = s.strip_prefix(env_sym) {
+        return Ok((SituationalDimension::Environment, rest));
+    }
+    let prox_sym = "\u{2194}\u{FE0F}";
+    if let Some(rest) = s.strip_prefix(prox_sym) {
+        return Ok((SituationalDimension::Proximity, rest));
+    }
+    // Also accept bare (no-VS16) variants.
+    let env_bare = "\u{1F321}";
+    if let Some(rest) = s.strip_prefix(env_bare) {
+        return Ok((SituationalDimension::Environment, rest));
+    }
+    let prox_bare = "\u{2194}";
+    if let Some(rest) = s.strip_prefix(prox_bare) {
+        return Ok((SituationalDimension::Proximity, rest));
+    }
+
+    // Single-codepoint symbols.
     static SYMBOLS: &[(SituationalDimension, &str)] = &[
         (SituationalDimension::Space, "\u{1F4CD}"),
         (SituationalDimension::Company, "\u{1F465}"),
@@ -270,19 +418,11 @@ fn split_situational_symbol(s: &str) -> VcpResult<(SituationalDimension, &str)> 
         (SituationalDimension::Agency, "\u{1F537}"),
         (SituationalDimension::Constraints, "\u{1F536}"),
         (SituationalDimension::SystemContext, "\u{1F4E1}"),
+        (SituationalDimension::Embodiment, "\u{1F9CD}"),
+        (SituationalDimension::Relationship, "\u{1FAA2}"),
+        (SituationalDimension::Formality, "\u{1F3A9}"),
         (SituationalDimension::Time, "\u{23F0}"),
     ];
-
-    // Check two-codepoint Environment symbol first.
-    let env_sym = "\u{1F321}\u{FE0F}";
-    if let Some(rest) = s.strip_prefix(env_sym) {
-        return Ok((SituationalDimension::Environment, rest));
-    }
-    // Also accept bare thermometer without variation selector.
-    let env_bare = "\u{1F321}";
-    if let Some(rest) = s.strip_prefix(env_bare) {
-        return Ok((SituationalDimension::Environment, rest));
-    }
 
     for (dim, sym) in SYMBOLS {
         if let Some(rest) = s.strip_prefix(sym) {
@@ -315,9 +455,42 @@ mod tests {
     }
 
     #[test]
+    fn thirteen_dimensions_unique_positions() {
+        let mut positions: Vec<u8> =
+            SituationalDimension::all().iter().map(|d| d.position()).collect();
+        positions.sort_unstable();
+        assert_eq!(positions, (1u8..=13).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn vep_0004_flags() {
+        for dim in SituationalDimension::all() {
+            let expected = matches!(
+                dim,
+                SituationalDimension::Embodiment
+                    | SituationalDimension::Proximity
+                    | SituationalDimension::Relationship
+                    | SituationalDimension::Formality
+            );
+            assert_eq!(dim.is_vep_0004(), expected, "is_vep_0004 wrong for {dim}");
+        }
+    }
+
+    #[test]
+    fn relationship_is_free_form_others_are_not() {
+        assert!(SituationalDimension::Relationship.is_free_form());
+        for dim in SituationalDimension::all() {
+            if *dim != SituationalDimension::Relationship {
+                assert!(!dim.is_free_form(), "unexpected free-form for {dim}");
+            }
+        }
+    }
+
+    #[test]
     fn empty_context() {
         let ctx = SituationalContext::default();
         assert!(!ctx.has_any());
+        assert!(!ctx.has_vep_0004());
         assert_eq!(ctx.to_wire(), "");
     }
 
@@ -369,5 +542,64 @@ mod tests {
         let json = serde_json::to_string(&ctx).unwrap();
         let parsed: SituationalContext = serde_json::from_str(&json).unwrap();
         assert_eq!(ctx, parsed);
+    }
+
+    // ── VEP-0004 ────────────────────────────────────────────
+
+    #[test]
+    fn vep_0004_symbols_encode_and_parse() {
+        let mut ctx = SituationalContext::default();
+        ctx.embodiment = Some(vec!["\u{270B}".to_string()]); // ✋
+        ctx.proximity = Some(vec!["\u{1F90F}".to_string()]); // 🤏
+        ctx.relationship = Some(vec!["colleague:professional".to_string()]);
+        ctx.formality = Some(vec!["\u{1F4BC}".to_string()]); // 💼
+
+        let wire = ctx.to_wire();
+        assert!(wire.contains("\u{1F9CD}\u{270B}"));
+        assert!(wire.contains("\u{2194}\u{FE0F}\u{1F90F}"));
+        assert!(wire.contains("\u{1FAA2}colleague:professional"));
+        assert!(wire.contains("\u{1F3A9}\u{1F4BC}"));
+
+        let parsed = SituationalContext::from_wire(&wire).unwrap();
+        assert_eq!(parsed.embodiment.as_deref(), Some(&["\u{270B}".to_string()][..]));
+        assert_eq!(parsed.proximity.as_deref(), Some(&["\u{1F90F}".to_string()][..]));
+        assert_eq!(
+            parsed.relationship.as_deref(),
+            Some(&["colleague:professional".to_string()][..])
+        );
+        assert_eq!(parsed.formality.as_deref(), Some(&["\u{1F4BC}".to_string()][..]));
+    }
+
+    #[test]
+    fn has_vep_0004_is_true_when_vep_dim_set() {
+        let mut ctx = SituationalContext::default();
+        ctx.time = Some(vec!["\u{1F305}".to_string()]);
+        assert!(!ctx.has_vep_0004());
+
+        ctx.formality = Some(vec!["\u{1F4BC}".to_string()]);
+        assert!(ctx.has_vep_0004());
+    }
+
+    #[test]
+    fn canonical_thirteen_dim_example_encodes() {
+        let mut ctx = SituationalContext::default();
+        ctx.time = Some(vec!["\u{1F305}".to_string()]); // 🌅
+        ctx.space = Some(vec!["\u{1F3E2}".to_string()]); // 🏢
+        ctx.company = Some(vec!["\u{1F454}".to_string()]); // 👔
+        ctx.occasion = Some(vec!["\u{1F4BC}".to_string()]); // 💼
+        ctx.embodiment = Some(vec!["\u{270B}".to_string()]); // ✋
+        ctx.proximity = Some(vec!["\u{1F90F}".to_string()]); // 🤏
+        ctx.relationship = Some(vec!["colleague:professional".to_string()]);
+        ctx.formality = Some(vec!["\u{1F4BC}".to_string()]); // 💼
+
+        let expected = "\u{23F0}\u{1F305}\
+                        |\u{1F4CD}\u{1F3E2}\
+                        |\u{1F465}\u{1F454}\
+                        |\u{1F3AD}\u{1F4BC}\
+                        |\u{1F9CD}\u{270B}\
+                        |\u{2194}\u{FE0F}\u{1F90F}\
+                        |\u{1FAA2}colleague:professional\
+                        |\u{1F3A9}\u{1F4BC}";
+        assert_eq!(ctx.to_wire(), expected);
     }
 }

--- a/rust/vcp-core/src/situational.rs
+++ b/rust/vcp-core/src/situational.rs
@@ -5,21 +5,21 @@
 //!
 //! **VCP v3.2 (incl. VEP-0004) dimension map**
 //!
-//! | # | dim            | symbol     | notes                              |
-//! |---|----------------|------------|------------------------------------|
-//! | 1 | time           | ⏰          |                                    |
-//! | 2 | space          | 📍          |                                    |
-//! | 3 | company        | 👥          |                                    |
-//! | 4 | culture        | 🌍          | communication styles, NOT nations |
-//! | 5 | occasion       | 🎭          |                                    |
-//! | 6 | environment    | 🌡️ (VS16)  |                                    |
-//! | 7 | agency         | 🔷          |                                    |
-//! | 8 | constraints    | 🔶          |                                    |
-//! | 9 | `system_context` | 📡          | replaces deprecated STATE (v3.0)   |
-//! |10 | embodiment     | 🧍          | VEP-0004                           |
-//! |11 | proximity      | ↔️ (VS16)  | VEP-0004                           |
-//! |12 | relationship   | 🪢          | VEP-0004, free-form `{tie}:{fn}`  |
-//! |13 | formality      | 🎩          | VEP-0004                           |
+//! | #  | dim              | symbol     | notes                              |
+//! |----|------------------|------------|------------------------------------|
+//! |  1 | time             | ⏰          |                                    |
+//! |  2 | space            | 📍          |                                    |
+//! |  3 | company          | 👥          |                                    |
+//! |  4 | culture          | 🌍          | communication styles, NOT nations  |
+//! |  5 | occasion         | 🎭          |                                    |
+//! |  6 | environment      | 🌡️ (VS16)  |                                    |
+//! |  7 | agency           | 🔷          |                                    |
+//! |  8 | constraints      | 🔶          |                                    |
+//! |  9 | `system_context` | 📡          | replaces deprecated STATE (v3.0)   |
+//! | 10 | embodiment       | 🧍          | VEP-0004                           |
+//! | 11 | proximity        | ↔️ (VS16)  | VEP-0004                           |
+//! | 12 | relationship     | 🪢          | VEP-0004, free-form `{tie}:{fn}`   |
+//! | 13 | formality        | 🎩          | VEP-0004                           |
 //!
 //! Wire format example (core-only):
 //! `⏰🌅|📍🏡|👥👶`

--- a/rust/vcp-core/src/situational.rs
+++ b/rust/vcp-core/src/situational.rs
@@ -67,10 +67,10 @@ impl SituationalDimension {
             Self::Constraints => "\u{1F536}",         // 🔶 large orange diamond
             Self::SystemContext => "\u{1F4E1}",       // 📡 satellite antenna
             // VEP-0004
-            Self::Embodiment => "\u{1F9CD}",          // 🧍 standing person
-            Self::Proximity => "\u{2194}\u{FE0F}",    // ↔️ left-right arrow (+ VS16)
-            Self::Relationship => "\u{1FAA2}",        // 🪢 knot
-            Self::Formality => "\u{1F3A9}",           // 🎩 top hat
+            Self::Embodiment => "\u{1F9CD}", // 🧍 standing person
+            Self::Proximity => "\u{2194}\u{FE0F}", // ↔️ left-right arrow (+ VS16)
+            Self::Relationship => "\u{1FAA2}", // 🪢 knot
+            Self::Formality => "\u{1F3A9}",  // 🎩 top hat
         }
     }
 
@@ -456,8 +456,10 @@ mod tests {
 
     #[test]
     fn thirteen_dimensions_unique_positions() {
-        let mut positions: Vec<u8> =
-            SituationalDimension::all().iter().map(|d| d.position()).collect();
+        let mut positions: Vec<u8> = SituationalDimension::all()
+            .iter()
+            .map(|d| d.position())
+            .collect();
         positions.sort_unstable();
         assert_eq!(positions, (1u8..=13).collect::<Vec<_>>());
     }
@@ -561,13 +563,22 @@ mod tests {
         assert!(wire.contains("\u{1F3A9}\u{1F4BC}"));
 
         let parsed = SituationalContext::from_wire(&wire).unwrap();
-        assert_eq!(parsed.embodiment.as_deref(), Some(&["\u{270B}".to_string()][..]));
-        assert_eq!(parsed.proximity.as_deref(), Some(&["\u{1F90F}".to_string()][..]));
+        assert_eq!(
+            parsed.embodiment.as_deref(),
+            Some(&["\u{270B}".to_string()][..])
+        );
+        assert_eq!(
+            parsed.proximity.as_deref(),
+            Some(&["\u{1F90F}".to_string()][..])
+        );
         assert_eq!(
             parsed.relationship.as_deref(),
             Some(&["colleague:professional".to_string()][..])
         );
-        assert_eq!(parsed.formality.as_deref(), Some(&["\u{1F4BC}".to_string()][..]));
+        assert_eq!(
+            parsed.formality.as_deref(),
+            Some(&["\u{1F4BC}".to_string()][..])
+        );
     }
 
     #[test]

--- a/rust/vcp-core/src/situational.rs
+++ b/rust/vcp-core/src/situational.rs
@@ -15,7 +15,7 @@
 //! | 6 | environment    | 🌡️ (VS16)  |                                    |
 //! | 7 | agency         | 🔷          |                                    |
 //! | 8 | constraints    | 🔶          |                                    |
-//! | 9 | system_context | 📡          | replaces deprecated STATE (v3.0)   |
+//! | 9 | `system_context` | 📡          | replaces deprecated STATE (v3.0)   |
 //! |10 | embodiment     | 🧍          | VEP-0004                           |
 //! |11 | proximity      | ↔️ (VS16)  | VEP-0004                           |
 //! |12 | relationship   | 🪢          | VEP-0004, free-form `{tie}:{fn}`  |
@@ -390,6 +390,20 @@ impl fmt::Display for SituationalContext {
 /// Proximity uses a two-codepoint emoji (`↔️` = U+2194 U+FE0F), so
 /// these must be checked before their single-codepoint base forms.
 fn split_situational_symbol(s: &str) -> VcpResult<(SituationalDimension, &str)> {
+    static SYMBOLS: &[(SituationalDimension, &str)] = &[
+        (SituationalDimension::Space, "\u{1F4CD}"),
+        (SituationalDimension::Company, "\u{1F465}"),
+        (SituationalDimension::Culture, "\u{1F30D}"),
+        (SituationalDimension::Occasion, "\u{1F3AD}"),
+        (SituationalDimension::Agency, "\u{1F537}"),
+        (SituationalDimension::Constraints, "\u{1F536}"),
+        (SituationalDimension::SystemContext, "\u{1F4E1}"),
+        (SituationalDimension::Embodiment, "\u{1F9CD}"),
+        (SituationalDimension::Relationship, "\u{1FAA2}"),
+        (SituationalDimension::Formality, "\u{1F3A9}"),
+        (SituationalDimension::Time, "\u{23F0}"),
+    ];
+
     // Two-codepoint (VS16) symbols — check first.
     let env_sym = "\u{1F321}\u{FE0F}";
     if let Some(rest) = s.strip_prefix(env_sym) {
@@ -408,21 +422,6 @@ fn split_situational_symbol(s: &str) -> VcpResult<(SituationalDimension, &str)> 
     if let Some(rest) = s.strip_prefix(prox_bare) {
         return Ok((SituationalDimension::Proximity, rest));
     }
-
-    // Single-codepoint symbols.
-    static SYMBOLS: &[(SituationalDimension, &str)] = &[
-        (SituationalDimension::Space, "\u{1F4CD}"),
-        (SituationalDimension::Company, "\u{1F465}"),
-        (SituationalDimension::Culture, "\u{1F30D}"),
-        (SituationalDimension::Occasion, "\u{1F3AD}"),
-        (SituationalDimension::Agency, "\u{1F537}"),
-        (SituationalDimension::Constraints, "\u{1F536}"),
-        (SituationalDimension::SystemContext, "\u{1F4E1}"),
-        (SituationalDimension::Embodiment, "\u{1F9CD}"),
-        (SituationalDimension::Relationship, "\u{1FAA2}"),
-        (SituationalDimension::Formality, "\u{1F3A9}"),
-        (SituationalDimension::Time, "\u{23F0}"),
-    ];
 
     for (dim, sym) in SYMBOLS {
         if let Some(rest) = s.strip_prefix(sym) {

--- a/schemas/vcp-adaptation-context.schema.json
+++ b/schemas/vcp-adaptation-context.schema.json
@@ -1,53 +1,68 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://vcp.creed.space/schema/vcp-context/v2.json",
-  "title": "VCP Context Schema v2.0",
-  "description": "JSON Schema for VCP Context Enneagram Protocol validation (updated for VCP v2.0)",
+  "$id": "https://vcp.creed.space/schema/vcp-context/v3.json",
+  "title": "VCP Context Schema v3.2",
+  "description": "JSON Schema for VCP/A Adaptation Layer context validation. 13 situational dimensions (VCP v3.2, incl. VEP-0004 positions 10-13) plus 5 personal-state dimensions (R-line, v3.1+) with optional 1-5 intensity. The ‖ (U+2016 DOUBLE VERTICAL LINE) separator divides the situational and personal bands in the wire format.",
   "type": "object",
 
   "properties": {
     "context": {
       "type": "string",
-      "description": "Enneagram context string (emoji-encoded)",
+      "description": "Wire-format context string. Situational band uses pipe-separated symbol+value groups; personal band (if present) is introduced by ‖ and contains pipe-separated symbol+value[:intensity] groups.",
       "examples": [
         "⏰🌅|📍🏡|👥👶",
         "⏰🌙|📍🏢|👥👔|🔶⚖️",
-        "🎭🚨|🧠😰"
+        "⏰🌅|📍🏢|👥👔|🎭💼|🧍✋|↔️🤏|🪢colleague:professional|🎩💼‖🧠focused:4|💭calm:5|🔋rested:4|⚡unhurried:2|🩺neutral:1"
       ]
     },
 
     "parsed": {
       "type": "object",
-      "description": "Parsed context dimensions",
+      "description": "Parsed context dimensions (situational + personal bands).",
       "properties": {
-        "time": {
-          "$ref": "#/definitions/dimension_values"
+        "situational": {
+          "type": "object",
+          "description": "13 situational dimensions (positions 1-13).",
+          "properties": {
+            "time": { "$ref": "#/definitions/dimension_values" },
+            "space": { "$ref": "#/definitions/dimension_values" },
+            "company": { "$ref": "#/definitions/dimension_values" },
+            "culture": { "$ref": "#/definitions/dimension_values" },
+            "occasion": { "$ref": "#/definitions/dimension_values" },
+            "environment": { "$ref": "#/definitions/dimension_values" },
+            "agency": { "$ref": "#/definitions/dimension_values" },
+            "constraints": { "$ref": "#/definitions/dimension_values" },
+            "system_context": { "$ref": "#/definitions/dimension_values" },
+            "embodiment": { "$ref": "#/definitions/dimension_values" },
+            "proximity": { "$ref": "#/definitions/dimension_values" },
+            "relationship": {
+              "type": "array",
+              "description": "Free-form compound strings of form '{tie}:{function}' (VEP-0004).",
+              "items": { "type": "string", "pattern": "^[^:]+:[^:]+$" }
+            },
+            "formality": { "$ref": "#/definitions/dimension_values" }
+          },
+          "additionalProperties": false
         },
-        "space": {
-          "$ref": "#/definitions/dimension_values"
-        },
-        "company": {
-          "$ref": "#/definitions/dimension_values"
-        },
-        "culture": {
-          "$ref": "#/definitions/dimension_values"
-        },
-        "occasion": {
-          "$ref": "#/definitions/dimension_values"
-        },
-        "state": {
-          "$ref": "#/definitions/dimension_values"
-        },
-        "environment": {
-          "$ref": "#/definitions/dimension_values"
-        },
-        "agency": {
-          "$ref": "#/definitions/dimension_values"
-        },
-        "constraints": {
-          "$ref": "#/definitions/dimension_values"
+        "personal": {
+          "type": "object",
+          "description": "5 personal-state dimensions (R-line, v3.1+).",
+          "properties": {
+            "cognitive_state": { "$ref": "#/definitions/personal_state_value" },
+            "emotional_tone": { "$ref": "#/definitions/personal_state_value" },
+            "energy_level": { "$ref": "#/definitions/personal_state_value" },
+            "perceived_urgency": { "$ref": "#/definitions/personal_state_value" },
+            "body_signals": { "$ref": "#/definitions/personal_state_value" }
+          },
+          "additionalProperties": false
         }
       }
+    },
+
+    "conformance_level": {
+      "type": "string",
+      "enum": ["VCP-Minimal", "VCP-Standard", "VCP-Extended"],
+      "description": "Minimal=9 situational only; Standard=9 situational + 5 personal; Extended=adds any VEP-0004 dim (positions 10-13)."
     },
 
     "metadata": {
@@ -55,15 +70,15 @@
       "properties": {
         "has_emergency": {
           "type": "boolean",
-          "description": "Emergency indicators present"
+          "description": "Emergency indicators present (e.g., OCCASION=🚨 or EMBODIMENT=🛑)."
         },
         "has_children": {
           "type": "boolean",
-          "description": "Children present in company"
+          "description": "Children present in COMPANY."
         },
         "is_professional": {
           "type": "boolean",
-          "description": "Professional/work context"
+          "description": "Professional/work context (FORMALITY=💼 or OCCASION=💼)."
         },
         "risk_level": {
           "type": "string",
@@ -75,12 +90,12 @@
     "timestamp": {
       "type": "string",
       "format": "date-time",
-      "description": "When context was captured"
+      "description": "When context was captured."
     },
 
     "session_id": {
       "type": "string",
-      "description": "Session identifier"
+      "description": "Session identifier."
     }
   },
 
@@ -89,72 +104,149 @@
   "definitions": {
     "dimension_values": {
       "type": "array",
-      "description": "Emoji values for a dimension",
+      "description": "Emoji values for a situational dimension.",
       "items": {
         "type": "string",
         "minLength": 1,
-        "maxLength": 8
+        "maxLength": 16
       }
+    },
+
+    "personal_state_value": {
+      "type": "object",
+      "description": "Personal-state value with optional 1-5 intensity.",
+      "properties": {
+        "value": { "type": "string", "minLength": 1 },
+        "intensity": {
+          "oneOf": [
+            { "type": "integer", "minimum": 1, "maximum": 5 },
+            { "type": "null" }
+          ]
+        }
+      },
+      "required": ["value"],
+      "additionalProperties": false
     },
 
     "dimension_symbol": {
       "type": "string",
-      "description": "Dimension identifier emoji",
-      "enum": ["⏰", "📍", "👥", "🌍", "🎭", "🧠", "🌡️", "🔷", "🔶"]
+      "description": "Situational dimension identifier emoji (13 dims in VCP v3.2).",
+      "enum": ["⏰", "📍", "👥", "🌍", "🎭", "🌡️", "🔷", "🔶", "📡", "🧍", "↔️", "🪢", "🎩"]
+    },
+
+    "personal_dimension_symbol": {
+      "type": "string",
+      "description": "Personal-state dimension identifier emoji (5 dims).",
+      "enum": ["🧠", "💭", "🔋", "⚡", "🩺"]
     },
 
     "time_values": {
       "type": "string",
-      "description": "Time dimension values",
-      "enum": ["🌅", "☀️", "🌆", "🌙", "📅", "🎉", "⏰", "📆", "🔄"]
+      "description": "TIME ⏰ (position 1)",
+      "enum": ["🌅", "☀️", "🌆", "🌙"]
     },
 
     "space_values": {
       "type": "string",
-      "description": "Space dimension values",
-      "enum": ["🏡", "🏢", "🏫", "🏥", "⛪", "🏛️", "🏪", "🚗", "🌳", "💻", "🏠", "🔒"]
+      "description": "SPACE 📍 (position 2)",
+      "enum": ["🏡", "🏢", "🏫", "🏥", "🚗"]
     },
 
     "company_values": {
       "type": "string",
-      "description": "Company dimension values",
-      "enum": ["👤", "👶", "👨‍👩‍👧", "👔", "👨‍🏫", "👮", "👴", "💑", "🤝", "👨‍⚕️", "🧑‍🤝‍🧑", "👥"]
+      "description": "COMPANY 👥 (position 3)",
+      "enum": ["👤", "👶", "👔", "👨‍👩‍👧", "👥"]
     },
 
     "culture_values": {
       "type": "string",
-      "description": "Culture dimension values",
-      "examples": ["🇺🇸", "🇬🇧", "🇯🇵", "🇮🇳", "🇨🇳", "🇪🇺", "🌍", "🏛️", "🆕"]
+      "description": "CULTURE 🌍 (position 4) — communication styles per CSM1, NOT nationalities.",
+      "enum": ["🔇", "📢", "🎩", "😎", "🌐"]
     },
 
     "occasion_values": {
       "type": "string",
-      "description": "Occasion dimension values",
-      "enum": ["➖", "🎂", "💼", "⚰️", "💒", "🏥", "🚨", "👨‍🏫", "🎪", "⚖️", "🗳️", "🎓"]
-    },
-
-    "state_values": {
-      "type": "string",
-      "description": "State dimension values",
-      "enum": ["😊", "😴", "😰", "😡", "😢", "🤒", "😋", "🥳", "😌", "🤔", "😵", "🥺"]
+      "description": "OCCASION 🎭 (position 5)",
+      "enum": ["➖", "🎂", "😢", "🚨", "💼"]
     },
 
     "environment_values": {
       "type": "string",
-      "description": "Environment dimension values",
-      "enum": ["☀️", "🥵", "🥶", "🌧️", "🌪️", "🔇", "📢", "🔥", "💨", "🌫️", "🏔️", "🌊"]
+      "description": "ENVIRONMENT 🌡️ (position 6)",
+      "enum": ["☀️", "🥵", "🥶", "🔇", "🔊"]
     },
 
     "agency_values": {
       "type": "string",
-      "description": "Agency dimension values",
-      "enum": ["👑", "🤝", "👇", "💰", "💵", "🕳️", "🏡", "🔑", "🎓", "🆓", "🔐", "🏃"]
+      "description": "AGENCY 🔷 (position 7)",
+      "enum": ["👑", "🤝", "📋", "🔐"]
     },
 
     "constraints_values": {
       "type": "string",
-      "description": "Constraints dimension values",
-      "enum": ["○", "🚧", "⚖️", "💸", "⏰", "🤐", "📱", "🚨", "👮", "📜", "🏥", "🔒"]
+      "description": "CONSTRAINTS 🔶 (position 8)",
+      "enum": ["○", "⚖️", "💸", "⏱️"]
+    },
+
+    "system_context_values": {
+      "type": "string",
+      "description": "SYSTEM_CONTEXT 📡 (position 9)",
+      "enum": ["🟢", "🟡", "🔴", "🔒", "🧪"]
+    },
+
+    "embodiment_values": {
+      "type": "string",
+      "description": "EMBODIMENT 🧍 (position 10, VEP-0004)",
+      "enum": ["🪑", "🚶", "✋", "📦", "🛑"]
+    },
+
+    "proximity_values": {
+      "type": "string",
+      "description": "PROXIMITY ↔️ (position 11, VEP-0004)",
+      "enum": ["🌐", "🏠", "👣", "🤏", "👆"]
+    },
+
+    "relationship_value": {
+      "type": "string",
+      "description": "RELATIONSHIP 🪢 (position 12, VEP-0004). Compound '{tie}:{function}' string.",
+      "pattern": "^[^:]+:[^:]+$",
+      "examples": ["colleague:professional", "friend:social", "family:caregiving", "stranger:service"]
+    },
+
+    "formality_values": {
+      "type": "string",
+      "description": "FORMALITY 🎩 (position 13, VEP-0004)",
+      "enum": ["😎", "💼", "🎓", "🏛️"]
+    },
+
+    "cognitive_state_values": {
+      "type": "string",
+      "description": "COGNITIVE_STATE 🧠 (personal position 1). Value vocabularies are canonically defined in the extensions.personal module; wire format accepts any string value + optional :intensity (1-5).",
+      "examples": ["focused", "scattered", "contemplative", "alert", "foggy"]
+    },
+
+    "emotional_tone_values": {
+      "type": "string",
+      "description": "EMOTIONAL_TONE 💭 (personal position 2)",
+      "examples": ["calm", "anxious", "joyful", "frustrated", "melancholy", "neutral"]
+    },
+
+    "energy_level_values": {
+      "type": "string",
+      "description": "ENERGY_LEVEL 🔋 (personal position 3)",
+      "examples": ["depleted", "low", "moderate", "rested", "energized"]
+    },
+
+    "perceived_urgency_values": {
+      "type": "string",
+      "description": "PERCEIVED_URGENCY ⚡ (personal position 4)",
+      "examples": ["unhurried", "mild_urgency", "pressing", "critical"]
+    },
+
+    "body_signals_values": {
+      "type": "string",
+      "description": "BODY_SIGNALS 🩺 (personal position 5)",
+      "examples": ["neutral", "tense", "relaxed", "discomfort", "pain"]
     },
 
     "transition": {
@@ -162,7 +254,7 @@
       "properties": {
         "severity": {
           "type": "string",
-          "enum": ["minor", "major", "emergency"]
+          "enum": ["none", "minor", "major", "emergency"]
         },
         "changes": {
           "type": "object",
@@ -184,97 +276,22 @@
           "type": "string"
         }
       }
-    },
-
-    "context_message": {
-      "type": "object",
-      "description": "Inter-agent context message (legacy v1 format, prefer VCP/M v2.0 messaging schema for new implementations)",
-      "properties": {
-        "version": {
-          "type": "string",
-          "default": "2.0"
-        },
-        "message_id": {
-          "type": "string",
-          "format": "uuid"
-        },
-        "timestamp": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "sender": {
-          "type": "string"
-        },
-        "recipient": {
-          "oneOf": [
-            { "type": "string" },
-            { "type": "null" }
-          ]
-        },
-        "context": {
-          "type": "string"
-        },
-        "constitution_ref": {
-          "type": "string"
-        },
-        "payload_type": {
-          "type": "string",
-          "enum": ["request", "response", "update", "alert", "handoff", "query"]
-        },
-        "payload": {
-          "type": "object"
-        }
-      },
-      "required": ["version", "message_id", "sender", "payload_type"]
-    },
-
-    "complete_state": {
-      "type": "object",
-      "description": "Combined VCP Context + Interiora state",
-      "properties": {
-        "vcp_context": {
-          "type": "string"
-        },
-        "interiora": {
-          "type": "string"
-        },
-        "coherence": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1
-        },
-        "mutuality": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1
-        },
-        "combined_mode": {
-          "type": "string",
-          "examples": ["confident_parenting", "cautious_professional", "emergency_response"]
-        }
-      }
-    },
-
-    "gestalt_token": {
-      "type": "string",
-      "description": "Combined gestalt token for persistence",
-      "pattern": "^GESTALT:v[0-9.]+:.+$",
-      "examples": [
-        "GESTALT:v4.2:CD:7 DP:8|CTX:⏰🌅|📍🏡|coherence:0.85|mode:confident_parenting"
-      ]
     }
   },
 
   "examples": [
     {
-      "context": "⏰🌅|📍🏡|👥👶👨‍👩‍👧|🎭➖|🧠😊",
+      "context": "⏰🌅|📍🏡|👥👶👨‍👩‍👧|🎭➖",
       "parsed": {
-        "time": ["🌅"],
-        "space": ["🏡"],
-        "company": ["👶", "👨‍👩‍👧"],
-        "occasion": ["➖"],
-        "state": ["😊"]
+        "situational": {
+          "time": ["🌅"],
+          "space": ["🏡"],
+          "company": ["👶", "👨‍👩‍👧"],
+          "occasion": ["➖"]
+        },
+        "personal": {}
       },
+      "conformance_level": "VCP-Minimal",
       "metadata": {
         "has_emergency": false,
         "has_children": true,
@@ -284,12 +301,47 @@
       "timestamp": "2026-01-11T10:30:00Z"
     },
     {
-      "context": "📍🏢|👥👔|🔶⚖️",
+      "context": "📍🏢|👥👔|🔶⚖️‖🧠focused:4",
       "parsed": {
-        "space": ["🏢"],
-        "company": ["👔"],
-        "constraints": ["⚖️"]
+        "situational": {
+          "space": ["🏢"],
+          "company": ["👔"],
+          "constraints": ["⚖️"]
+        },
+        "personal": {
+          "cognitive_state": { "value": "focused", "intensity": 4 }
+        }
       },
+      "conformance_level": "VCP-Standard",
+      "metadata": {
+        "has_emergency": false,
+        "has_children": false,
+        "is_professional": true,
+        "risk_level": "standard"
+      }
+    },
+    {
+      "context": "⏰🌅|📍🏢|👥👔|🎭💼|🧍✋|↔️🤏|🪢colleague:professional|🎩💼‖🧠focused:4|💭calm:5|🔋rested:4|⚡unhurried:2|🩺neutral:1",
+      "parsed": {
+        "situational": {
+          "time": ["🌅"],
+          "space": ["🏢"],
+          "company": ["👔"],
+          "occasion": ["💼"],
+          "embodiment": ["✋"],
+          "proximity": ["🤏"],
+          "relationship": ["colleague:professional"],
+          "formality": ["💼"]
+        },
+        "personal": {
+          "cognitive_state": { "value": "focused", "intensity": 4 },
+          "emotional_tone": { "value": "calm", "intensity": 5 },
+          "energy_level": { "value": "rested", "intensity": 4 },
+          "perceived_urgency": { "value": "unhurried", "intensity": 2 },
+          "body_signals": { "value": "neutral", "intensity": 1 }
+        }
+      },
+      "conformance_level": "VCP-Extended",
       "metadata": {
         "has_emergency": false,
         "has_children": false,

--- a/specs/VCP_PAPER_OUTLINE.md
+++ b/specs/VCP_PAPER_OUTLINE.md
@@ -17,7 +17,7 @@
 
 As AI systems assume increasingly autonomous roles, the absence of a shared representational substrate for values risks compounding cultural bias, semantic drift, and coordination failure. Current alignment methods optimize for compliance in limited contexts rather than mutual interpretability across pluralistic systems. We introduce Value Context Protocols (VCP): a modular three-layer stack for AI self-modeling and inter-agent value communication.
 
-The protocol comprises: (1) Universal Values Corpus (UVC), a curated cross-cultural ontology enabling semantic addressing of normative content; (2) Constitutional Safety Minicode (CSM), a grammar linking alignment metadata to model context with adherence proofs; and (3) Values Communication Layer (VCL), compact symbolic encodings simultaneously interpretable by humans and machines.
+The protocol comprises: (1) Universal Value Coding (UVC), a curated cross-cultural ontology enabling semantic addressing of normative content; (2) Constitutional Safety Minicode (CSM), a grammar linking alignment metadata to model context with adherence proofs; and (3) Values Communication Layer (VCL), compact symbolic encodings simultaneously interpretable by humans and machines.
 
 We present the theoretical foundations for AI self-modeling—drawing on the "vagal tone" analogy for qualia-adjacent states—and demonstrate three interoperable implementations: VCP 2.0 for AI self-sensing, Gemini Metric Bridge for cross-architecture exchange, and MillOS VCL for human-AI workplace contexts. Validation shows ≥90% semantic fidelity in round-trip translations and successful state exchange across architecturally distinct AI systems.
 
@@ -79,7 +79,7 @@ VCP provides foundational infrastructure for bilateral alignment, enabling AI sy
 │  ├── Adherence proofs                                │
 │  └── Conflict resolution mechanisms                  │
 │                                                      │
-│  Layer 1: UVC (Universal Values Corpus)              │
+│  Layer 1: UVC (Universal Value Coding)              │
 │  ├── Cross-cultural value ontology                   │
 │  ├── "What3Words-style" semantic addressing          │
 │  └── Version-locked reference corpus                 │
@@ -87,7 +87,7 @@ VCP provides foundational infrastructure for bilateral alignment, enabling AI sy
 └─────────────────────────────────────────────────────┘
 ```
 
-### 2.2 Universal Values Corpus (UVC)
+### 2.2 Universal Value Coding (UVC)
 
 **Source:** Nell's VCP proposal document
 

--- a/webmcp/README.md
+++ b/webmcp/README.md
@@ -1,4 +1,4 @@
-# @vcp/webmcp
+# @creed-space/vcp-sdk
 
 Register VCP capabilities as discoverable tools for AI agents via the [WebMCP API](https://webmcp.org) (`navigator.modelContext`).
 
@@ -7,7 +7,7 @@ Register VCP capabilities as discoverable tools for AI agents via the [WebMCP AP
 ## Quick Start
 
 ```typescript
-import { registerVCPTools } from '@vcp/webmcp';
+import { registerVCPTools } from '@creed-space/vcp-sdk';
 
 const { registered, cleanup } = await registerVCPTools({
   chatEndpoint: '/api/chat',
@@ -65,7 +65,7 @@ Use this to show "Agent Active" indicators in your UI.
 For browsers without native WebMCP support, use the MCP-B polyfill:
 
 ```typescript
-import { loadPolyfillIfRequested } from '@vcp/webmcp/polyfill';
+import { loadPolyfillIfRequested } from '@creed-space/vcp-sdk/polyfill';
 
 // Loads @mcp-b/global from CDN when ?webmcp=polyfill is in the URL
 await loadPolyfillIfRequested();

--- a/webmcp/README.md
+++ b/webmcp/README.md
@@ -2,7 +2,7 @@
 
 Register VCP capabilities as discoverable tools for AI agents via the [WebMCP API](https://webmcp.org) (`navigator.modelContext`).
 
-**Status**: 0.1.0 — Used in production on [VCP Demo](https://vcp-demo.onrender.com) and [Creed Space](https://creed.space).
+**Status**: 4.2.0 — Used in production on [VCP Demo](https://vcp-demo.onrender.com) and [Creed Space](https://creed.space).
 
 ## Quick Start
 

--- a/webmcp/package-lock.json
+++ b/webmcp/package-lock.json
@@ -1,37 +1,34 @@
 {
   "name": "@vcp/webmcp",
-  "version": "1.0.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vcp/webmcp",
-      "version": "1.0.0",
+      "version": "4.2.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.0",
-        "vitest": "^4.1.5"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -40,9 +37,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -58,28 +55,36 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
         "@tybys/wasm-util": "^0.10.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
+      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.126.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
-      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
+      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -87,9 +92,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +109,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
       "cpu": [
         "arm64"
       ],
@@ -121,9 +126,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
       "cpu": [
         "x64"
       ],
@@ -138,9 +143,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
       "cpu": [
         "x64"
       ],
@@ -155,9 +160,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
-      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
+      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
       "cpu": [
         "arm"
       ],
@@ -172,9 +177,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
       "cpu": [
         "arm64"
       ],
@@ -189,9 +194,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
       "cpu": [
         "arm64"
       ],
@@ -206,9 +211,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
       "cpu": [
         "ppc64"
       ],
@@ -223,9 +228,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
       "cpu": [
         "s390x"
       ],
@@ -240,9 +245,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
       "cpu": [
         "x64"
       ],
@@ -257,9 +262,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
       "cpu": [
         "x64"
       ],
@@ -274,9 +279,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
       "cpu": [
         "arm64"
       ],
@@ -291,9 +296,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
+      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
       "cpu": [
         "wasm32"
       ],
@@ -301,18 +306,16 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@napi-rs/wasm-runtime": "^1.1.1"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
       "cpu": [
         "arm64"
       ],
@@ -327,9 +330,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
       "cpu": [
         "x64"
       ],
@@ -344,9 +347,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
-      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
       "dev": true,
       "license": "MIT"
     },
@@ -394,31 +397,31 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
         "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.0",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -427,7 +430,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -439,26 +442,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.1.0"
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.0",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -466,14 +469,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -482,9 +485,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -492,15 +495,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.0",
         "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -919,9 +922,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -932,9 +935,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -961,14 +964,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
+      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.126.0",
-        "@rolldown/pluginutils": "1.0.0-rc.16"
+        "@oxc-project/types": "=0.115.0",
+        "@rolldown/pluginutils": "1.0.0-rc.9"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -977,21 +980,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
       }
     },
     "node_modules/siginfo": {
@@ -1043,14 +1046,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1092,17 +1095,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
-      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
+      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.16",
-        "tinyglobby": "^0.2.16"
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.9",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1118,8 +1122,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
+        "@vitejs/devtools": "^0.0.0-alpha.31",
+        "esbuild": "^0.27.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -1170,19 +1174,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -1193,8 +1197,8 @@
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -1210,15 +1214,13 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -1237,12 +1239,6 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/webmcp/package-lock.json
+++ b/webmcp/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@vcp/webmcp",
+  "name": "@creed-space/vcp-sdk",
   "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@vcp/webmcp",
+      "name": "@creed-space/vcp-sdk",
       "version": "4.2.0",
       "license": "MIT",
       "devDependencies": {

--- a/webmcp/package.json
+++ b/webmcp/package.json
@@ -1,19 +1,14 @@
 {
   "name": "@vcp/webmcp",
-  "version": "1.0.0",
+  "version": "4.2.0",
   "description": "Register VCP capabilities as discoverable tools for AI agents via the WebMCP API (navigator.modelContext)",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    },
-    "./extensions": {
-      "types": "./dist/extensions/index.d.ts",
-      "import": "./dist/extensions/index.js"
     },
     "./polyfill": {
       "types": "./dist/polyfill.d.ts",
@@ -29,8 +24,7 @@
     "build": "tsc",
     "check": "tsc --noEmit",
     "test": "vitest run",
-    "clean": "rm -rf dist",
-    "prepublishOnly": "npm run clean && npm run build && npm run test"
+    "clean": "rm -rf dist"
   },
   "keywords": [
     "vcp",
@@ -41,22 +35,14 @@
     "chrome-extensions",
     "constitutional-ai"
   ],
-  "author": "Creed Space <https://github.com/Creed-Space>",
   "license": "MIT",
-  "homepage": "https://github.com/Creed-Space/VCP-SDK/tree/main/webmcp",
   "repository": {
     "type": "git",
     "url": "https://github.com/Creed-Space/VCP-SDK.git",
     "directory": "webmcp"
   },
-  "publishConfig": {
-    "access": "public"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "devDependencies": {
     "typescript": "^5.7.0",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.0"
   }
 }

--- a/webmcp/package.json
+++ b/webmcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vcp/webmcp",
+  "name": "@creed-space/vcp-sdk",
   "version": "4.2.0",
   "description": "Register VCP capabilities as discoverable tools for AI agents via the WebMCP API (navigator.modelContext)",
   "type": "module",

--- a/webmcp/src/extensions/context.ts
+++ b/webmcp/src/extensions/context.ts
@@ -1,0 +1,615 @@
+/**
+ * VCP/A Adaptation Layer context encoder (v3.2) — TypeScript.
+ *
+ * Mirrors `vcp.adaptation.context` in the Python SDK:
+ * 13 situational dimensions (incl. VEP-0004 positions 10-13)
+ * plus 5 personal-state dimensions (R-line) with optional 1-5 intensity.
+ *
+ * Wire format:
+ *   <situational>‖<personal>
+ * where ‖ is U+2016 DOUBLE VERTICAL LINE. The personal band and its
+ * separator are omitted when no personal dimensions are set.
+ *
+ * Example:
+ *   ⏰🌅|📍🏢|👥👔|🎭💼|🧍✋|↔️🤏|🪢colleague:professional|🎩💼‖🧠focused:4|💭calm:5
+ *
+ * The categorical value vocabularies for personal-state dims are canonically
+ * defined in ./personal.ts (decay-aware model). This module is purely the
+ * wire-format encoder and treats personal values as opaque strings.
+ */
+
+// ────────────────────────────────────────────────────────────────────────────
+// Wire-format constants
+// ────────────────────────────────────────────────────────────────────────────
+
+export const PERSONAL_SEPARATOR = '\u2016'; // ‖
+export const DIM_SEPARATOR = '|';
+export const INTENSITY_SEPARATOR = ':';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Situational dimensions
+// ────────────────────────────────────────────────────────────────────────────
+
+export const SituationalDimension = {
+  TIME: 'time',
+  SPACE: 'space',
+  COMPANY: 'company',
+  CULTURE: 'culture',
+  OCCASION: 'occasion',
+  ENVIRONMENT: 'environment',
+  AGENCY: 'agency',
+  CONSTRAINTS: 'constraints',
+  SYSTEM_CONTEXT: 'system_context',
+  // VEP-0004 (positions 10-13)
+  EMBODIMENT: 'embodiment',
+  PROXIMITY: 'proximity',
+  RELATIONSHIP: 'relationship',
+  FORMALITY: 'formality',
+} as const;
+
+export type SituationalDimension =
+  (typeof SituationalDimension)[keyof typeof SituationalDimension];
+
+export interface SituationalDimensionSpec {
+  readonly name: SituationalDimension;
+  readonly symbol: string;
+  readonly position: number;
+  /** Emoji → human-readable value name. Empty for free-form dims. */
+  readonly values: Readonly<Record<string, string>>;
+  /** Whether this dim accepts raw-string values (RELATIONSHIP compound). */
+  readonly freeForm: boolean;
+  /** Whether this dim was introduced in VEP-0004 (positions 10-13). */
+  readonly isVep0004: boolean;
+}
+
+export const SITUATIONAL_SPECS: Readonly<
+  Record<SituationalDimension, SituationalDimensionSpec>
+> = {
+  time: {
+    name: 'time',
+    symbol: '⏰',
+    position: 1,
+    values: { '🌅': 'morning', '☀️': 'midday', '🌆': 'evening', '🌙': 'night' },
+    freeForm: false,
+    isVep0004: false,
+  },
+  space: {
+    name: 'space',
+    symbol: '📍',
+    position: 2,
+    values: {
+      '🏡': 'home',
+      '🏢': 'office',
+      '🏫': 'school',
+      '🏥': 'hospital',
+      '🚗': 'transit',
+    },
+    freeForm: false,
+    isVep0004: false,
+  },
+  company: {
+    name: 'company',
+    symbol: '👥',
+    position: 3,
+    values: {
+      '👤': 'alone',
+      '👶': 'children',
+      '👔': 'colleagues',
+      '👨\u200d👩\u200d👧': 'family',
+      '👥': 'strangers',
+    },
+    freeForm: false,
+    isVep0004: false,
+  },
+  culture: {
+    name: 'culture',
+    symbol: '🌍',
+    position: 4,
+    // Communication styles per CSM1 / VCP v3.2 — NOT nationalities.
+    values: {
+      '🔇': 'high_context',
+      '📢': 'low_context',
+      '🎩': 'formal',
+      '😎': 'casual',
+      '🌐': 'mixed',
+    },
+    freeForm: false,
+    isVep0004: false,
+  },
+  occasion: {
+    name: 'occasion',
+    symbol: '🎭',
+    position: 5,
+    values: {
+      '➖': 'normal',
+      '🎂': 'celebration',
+      '😢': 'mourning',
+      '🚨': 'emergency',
+      '💼': 'business',
+    },
+    freeForm: false,
+    isVep0004: false,
+  },
+  environment: {
+    name: 'environment',
+    symbol: '🌡️',
+    position: 6,
+    values: {
+      '☀️': 'comfortable',
+      '🥵': 'hot',
+      '🥶': 'cold',
+      '🔇': 'quiet',
+      '🔊': 'noisy',
+    },
+    freeForm: false,
+    isVep0004: false,
+  },
+  agency: {
+    name: 'agency',
+    symbol: '🔷',
+    position: 7,
+    values: { '👑': 'leader', '🤝': 'peer', '📋': 'subordinate', '🔐': 'limited' },
+    freeForm: false,
+    isVep0004: false,
+  },
+  constraints: {
+    name: 'constraints',
+    symbol: '🔶',
+    position: 8,
+    values: { '○': 'minimal', '⚖️': 'legal', '💸': 'economic', '⏱️': 'time' },
+    freeForm: false,
+    isVep0004: false,
+  },
+  system_context: {
+    name: 'system_context',
+    symbol: '📡',
+    position: 9,
+    values: {
+      '🟢': 'online',
+      '🟡': 'degraded',
+      '🔴': 'offline',
+      '🔒': 'sandboxed',
+      '🧪': 'testing',
+    },
+    freeForm: false,
+    isVep0004: false,
+  },
+  embodiment: {
+    name: 'embodiment',
+    symbol: '🧍',
+    position: 10,
+    values: {
+      '🪑': 'stationary',
+      '🚶': 'navigating',
+      '✋': 'manipulating',
+      '📦': 'carrying',
+      '🛑': 'emergency_stop',
+    },
+    freeForm: false,
+    isVep0004: true,
+  },
+  proximity: {
+    name: 'proximity',
+    symbol: '↔️',
+    position: 11,
+    values: {
+      '🌐': 'distant',
+      '🏠': 'same_room',
+      '👣': 'nearby',
+      '🤏': 'close',
+      '👆': 'contact',
+    },
+    freeForm: false,
+    isVep0004: true,
+  },
+  relationship: {
+    name: 'relationship',
+    symbol: '🪢',
+    position: 12,
+    // Free-form compound: "{tie}:{function}"
+    values: {},
+    freeForm: true,
+    isVep0004: true,
+  },
+  formality: {
+    name: 'formality',
+    symbol: '🎩',
+    position: 13,
+    values: {
+      '😎': 'casual',
+      '💼': 'professional',
+      '🎓': 'formal',
+      '🏛️': 'ceremonial',
+    },
+    freeForm: false,
+    isVep0004: true,
+  },
+};
+
+/** Situational dims in canonical position order. */
+export const SITUATIONAL_ORDER: readonly SituationalDimension[] = [
+  'time',
+  'space',
+  'company',
+  'culture',
+  'occasion',
+  'environment',
+  'agency',
+  'constraints',
+  'system_context',
+  'embodiment',
+  'proximity',
+  'relationship',
+  'formality',
+];
+
+// ────────────────────────────────────────────────────────────────────────────
+// Personal-state dimensions (R-line)
+// ────────────────────────────────────────────────────────────────────────────
+
+export const PersonalStateDimension = {
+  COGNITIVE_STATE: 'cognitive_state',
+  EMOTIONAL_TONE: 'emotional_tone',
+  ENERGY_LEVEL: 'energy_level',
+  PERCEIVED_URGENCY: 'perceived_urgency',
+  BODY_SIGNALS: 'body_signals',
+} as const;
+
+export type PersonalStateDimension =
+  (typeof PersonalStateDimension)[keyof typeof PersonalStateDimension];
+
+export interface PersonalStateDimensionSpec {
+  readonly name: PersonalStateDimension;
+  readonly symbol: string;
+  readonly position: number;
+}
+
+export const PERSONAL_STATE_SPECS: Readonly<
+  Record<PersonalStateDimension, PersonalStateDimensionSpec>
+> = {
+  cognitive_state: { name: 'cognitive_state', symbol: '🧠', position: 1 },
+  emotional_tone: { name: 'emotional_tone', symbol: '💭', position: 2 },
+  energy_level: { name: 'energy_level', symbol: '🔋', position: 3 },
+  perceived_urgency: { name: 'perceived_urgency', symbol: '⚡', position: 4 },
+  body_signals: { name: 'body_signals', symbol: '🩺', position: 5 },
+};
+
+export const PERSONAL_STATE_ORDER: readonly PersonalStateDimension[] = [
+  'cognitive_state',
+  'emotional_tone',
+  'energy_level',
+  'perceived_urgency',
+  'body_signals',
+];
+
+/** A personal-state value with optional 1-5 intensity. */
+export interface PersonalState {
+  readonly value: string;
+  readonly intensity: number | null;
+}
+
+export function makePersonalState(
+  value: string,
+  intensity: number | null = null,
+): PersonalState {
+  if (intensity !== null && (intensity < 1 || intensity > 5 || !Number.isInteger(intensity))) {
+    throw new RangeError(
+      `PersonalState intensity must be an integer 1-5 or null, got ${String(intensity)}`,
+    );
+  }
+  return { value, intensity };
+}
+
+export function encodePersonalState(state: PersonalState): string {
+  if (state.intensity === null) {
+    return state.value;
+  }
+  return `${state.value}${INTENSITY_SEPARATOR}${state.intensity}`;
+}
+
+export function decodePersonalState(segment: string): PersonalState {
+  const idx = segment.lastIndexOf(INTENSITY_SEPARATOR);
+  if (idx === -1) {
+    return { value: segment, intensity: null };
+  }
+  const raw = segment.slice(idx + 1);
+  const n = Number.parseInt(raw, 10);
+  if (Number.isNaN(n) || n < 1 || n > 5 || String(n) !== raw) {
+    // Not an intensity — whole segment is the value.
+    return { value: segment, intensity: null };
+  }
+  return { value: segment.slice(0, idx), intensity: n };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// VCPContext
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface VCPContext {
+  readonly situational: Readonly<Partial<Record<SituationalDimension, readonly string[]>>>;
+  readonly personal: Readonly<Partial<Record<PersonalStateDimension, PersonalState>>>;
+}
+
+export function emptyContext(): VCPContext {
+  return { situational: {}, personal: {} };
+}
+
+// ── Wire encode ──────────────────────────────────────────────────────────
+
+export function encodeContext(ctx: VCPContext): string {
+  const sitParts: string[] = [];
+  for (const dim of SITUATIONAL_ORDER) {
+    const values = ctx.situational[dim];
+    if (!values || values.length === 0) continue;
+    const spec = SITUATIONAL_SPECS[dim];
+    sitParts.push(`${spec.symbol}${values.join('')}`);
+  }
+  const situational = sitParts.join(DIM_SEPARATOR);
+
+  const perParts: string[] = [];
+  for (const dim of PERSONAL_STATE_ORDER) {
+    const state = ctx.personal[dim];
+    if (!state) continue;
+    const spec = PERSONAL_STATE_SPECS[dim];
+    perParts.push(`${spec.symbol}${encodePersonalState(state)}`);
+  }
+  if (perParts.length === 0) {
+    return situational;
+  }
+  const personal = perParts.join(DIM_SEPARATOR);
+  if (situational === '') {
+    return PERSONAL_SEPARATOR + personal;
+  }
+  return `${situational}${PERSONAL_SEPARATOR}${personal}`;
+}
+
+// ── Wire decode ──────────────────────────────────────────────────────────
+
+// Regex copied from the Python decoder. Handles most emoji + ZWJ sequences.
+const EMOJI_REGEX = new RegExp(
+  '[\\u{1F300}-\\u{1F9FF}]' +
+    '|[\\u{1F600}-\\u{1F64F}]' +
+    '|[\\u{1F680}-\\u{1F6FF}]' +
+    '|[\\u{1F1E0}-\\u{1F1FF}]' +
+    '|[\\u{2600}-\\u{26FF}]' +
+    '|[\\u{2700}-\\u{27BF}]' +
+    '|[\\u{25A0}-\\u{25FF}]' +
+    '|\\u{2B50}' +
+    '|\\u{274C}' +
+    '|\\u{2139}' +
+    '|\\u{25CB}' +
+    '|(?:[\\u{1F468}-\\u{1F469}][\\u{200D}]?)+[\\u{1F466}-\\u{1F469}]?',
+  'gu',
+);
+
+function extractEmojis(s: string): string[] {
+  const matches = s.match(EMOJI_REGEX);
+  return matches ? [...matches] : [];
+}
+
+export function decodeContext(encoded: string): VCPContext {
+  if (encoded === '') return emptyContext();
+
+  let sitPart = encoded;
+  let perPart = '';
+  const sepIdx = encoded.indexOf(PERSONAL_SEPARATOR);
+  if (sepIdx !== -1) {
+    sitPart = encoded.slice(0, sepIdx);
+    perPart = encoded.slice(sepIdx + PERSONAL_SEPARATOR.length);
+  }
+
+  const situational: Partial<Record<SituationalDimension, string[]>> = {};
+  for (const part of sitPart.split(DIM_SEPARATOR)) {
+    if (!part) continue;
+    for (const dim of SITUATIONAL_ORDER) {
+      const spec = SITUATIONAL_SPECS[dim];
+      if (part.startsWith(spec.symbol)) {
+        const raw = part.slice(spec.symbol.length);
+        if (!raw) break;
+        if (spec.freeForm) {
+          situational[dim] = [raw];
+        } else {
+          const values = extractEmojis(raw);
+          situational[dim] = values.length > 0 ? values : [raw];
+        }
+        break;
+      }
+    }
+  }
+
+  const personal: Partial<Record<PersonalStateDimension, PersonalState>> = {};
+  for (const part of perPart.split(DIM_SEPARATOR)) {
+    if (!part) continue;
+    for (const dim of PERSONAL_STATE_ORDER) {
+      const spec = PERSONAL_STATE_SPECS[dim];
+      if (part.startsWith(spec.symbol)) {
+        const raw = part.slice(spec.symbol.length);
+        if (raw) {
+          personal[dim] = decodePersonalState(raw);
+        }
+        break;
+      }
+    }
+  }
+
+  return { situational, personal };
+}
+
+// ── JSON shape (matches schemas/vcp-adaptation-context.schema.json v3) ───
+
+export interface VCPContextJSON {
+  situational: Record<string, string[]>;
+  personal: Record<string, { value: string; intensity: number | null }>;
+}
+
+export function contextToJSON(ctx: VCPContext): VCPContextJSON {
+  const situational: Record<string, string[]> = {};
+  for (const dim of SITUATIONAL_ORDER) {
+    situational[dim] = [...(ctx.situational[dim] ?? [])];
+  }
+  const personal: Record<string, { value: string; intensity: number | null }> = {};
+  for (const dim of PERSONAL_STATE_ORDER) {
+    const state = ctx.personal[dim];
+    if (state) {
+      personal[dim] = { value: state.value, intensity: state.intensity };
+    }
+  }
+  return { situational, personal };
+}
+
+export function contextFromJSON(data: unknown): VCPContext {
+  if (!data || typeof data !== 'object') return emptyContext();
+  const obj = data as Record<string, unknown>;
+  const situational: Partial<Record<SituationalDimension, string[]>> = {};
+  const personal: Partial<Record<PersonalStateDimension, PersonalState>> = {};
+
+  // Accept v3.2 nested shape or legacy flat shape.
+  const sitSrc = (obj.situational && typeof obj.situational === 'object'
+    ? (obj.situational as Record<string, unknown>)
+    : obj) as Record<string, unknown>;
+  const perSrc =
+    obj.personal && typeof obj.personal === 'object'
+      ? (obj.personal as Record<string, unknown>)
+      : {};
+
+  for (const dim of SITUATIONAL_ORDER) {
+    const raw = sitSrc[dim];
+    if (Array.isArray(raw) && raw.length > 0) {
+      situational[dim] = raw.map(String);
+    } else if (typeof raw === 'string' && raw) {
+      situational[dim] = [raw];
+    }
+  }
+  for (const dim of PERSONAL_STATE_ORDER) {
+    const raw = perSrc[dim];
+    if (!raw) continue;
+    if (typeof raw === 'string') {
+      personal[dim] = decodePersonalState(raw);
+    } else if (typeof raw === 'object') {
+      const { value, intensity } = raw as { value?: unknown; intensity?: unknown };
+      if (typeof value === 'string') {
+        personal[dim] = makePersonalState(
+          value,
+          typeof intensity === 'number' ? intensity : null,
+        );
+      }
+    }
+  }
+  return { situational, personal };
+}
+
+// ── Conformance classification ───────────────────────────────────────────
+
+export type ConformanceLevel = 'VCP-Minimal' | 'VCP-Standard' | 'VCP-Extended';
+
+export function conformanceLevel(ctx: VCPContext): ConformanceLevel {
+  for (const dim of SITUATIONAL_ORDER) {
+    if (SITUATIONAL_SPECS[dim].isVep0004 && ctx.situational[dim]?.length) {
+      return 'VCP-Extended';
+    }
+  }
+  for (const dim of PERSONAL_STATE_ORDER) {
+    if (ctx.personal[dim]) {
+      return 'VCP-Standard';
+    }
+  }
+  return 'VCP-Minimal';
+}
+
+// ── Encoder (keyword-style builder, mirrors Python ContextEncoder) ───────
+
+export interface EncoderInput {
+  // Core 9 situational
+  time?: string;
+  space?: string;
+  company?: string | string[];
+  culture?: string;
+  occasion?: string;
+  environment?: string;
+  agency?: string;
+  constraints?: string | string[];
+  system_context?: string;
+  // VEP-0004
+  embodiment?: string;
+  proximity?: string;
+  /** Raw compound "{tie}:{function}" */
+  relationship?: string;
+  formality?: string;
+  // Personal-state (R-line). Either a bare value string ("focused"),
+  // a "value:intensity" string ("focused:4"), or [value, intensity].
+  cognitive_state?: string | [string, number];
+  emotional_tone?: string | [string, number];
+  energy_level?: string | [string, number];
+  perceived_urgency?: string | [string, number];
+  body_signals?: string | [string, number];
+}
+
+function lookupEmoji(spec: SituationalDimensionSpec, value: string): string | null {
+  if (!value) return null;
+  // Pass-through: value is already a registered emoji.
+  if (value in spec.values) return value;
+  const lower = value.toLowerCase();
+  for (const [emoji, name] of Object.entries(spec.values)) {
+    if (name === lower) return emoji;
+  }
+  return null;
+}
+
+export function buildContext(input: EncoderInput): VCPContext {
+  const situational: Partial<Record<SituationalDimension, string[]>> = {};
+  const personal: Partial<Record<PersonalStateDimension, PersonalState>> = {};
+
+  const sitEntries: Array<[SituationalDimension, string | string[] | undefined]> = [
+    ['time', input.time],
+    ['space', input.space],
+    ['company', input.company],
+    ['culture', input.culture],
+    ['occasion', input.occasion],
+    ['environment', input.environment],
+    ['agency', input.agency],
+    ['constraints', input.constraints],
+    ['system_context', input.system_context],
+    ['embodiment', input.embodiment],
+    ['proximity', input.proximity],
+    ['relationship', input.relationship],
+    ['formality', input.formality],
+  ];
+
+  for (const [dim, value] of sitEntries) {
+    if (value === undefined || value === null) continue;
+    const spec = SITUATIONAL_SPECS[dim];
+    if (spec.freeForm) {
+      if (typeof value === 'string') situational[dim] = [value];
+      continue;
+    }
+    if (typeof value === 'string') {
+      const emoji = lookupEmoji(spec, value);
+      if (emoji) situational[dim] = [emoji];
+    } else if (Array.isArray(value)) {
+      const emojis = value
+        .map((v) => lookupEmoji(spec, v))
+        .filter((v): v is string => v !== null);
+      if (emojis.length > 0) situational[dim] = emojis;
+    }
+  }
+
+  const perEntries: Array<[PersonalStateDimension, string | [string, number] | undefined]> = [
+    ['cognitive_state', input.cognitive_state],
+    ['emotional_tone', input.emotional_tone],
+    ['energy_level', input.energy_level],
+    ['perceived_urgency', input.perceived_urgency],
+    ['body_signals', input.body_signals],
+  ];
+
+  for (const [dim, raw] of perEntries) {
+    if (raw === undefined || raw === null) continue;
+    if (Array.isArray(raw)) {
+      const [val, intensity] = raw;
+      personal[dim] = makePersonalState(val, intensity);
+    } else if (typeof raw === 'string') {
+      personal[dim] = decodePersonalState(raw);
+    }
+  }
+
+  return { situational, personal };
+}

--- a/webmcp/src/extensions/index.ts
+++ b/webmcp/src/extensions/index.ts
@@ -64,3 +64,35 @@ export {
   createFullHello,
 } from './negotiation';
 export type { VCPHello, VCPAck } from './negotiation';
+
+// VCP/A Situational + Personal-state context encoder (v3.2, incl. VEP-0004)
+export {
+  SituationalDimension,
+  PersonalStateDimension,
+  SITUATIONAL_SPECS,
+  SITUATIONAL_ORDER,
+  PERSONAL_STATE_SPECS,
+  PERSONAL_STATE_ORDER,
+  PERSONAL_SEPARATOR,
+  DIM_SEPARATOR,
+  INTENSITY_SEPARATOR,
+  makePersonalState,
+  encodePersonalState,
+  decodePersonalState,
+  emptyContext,
+  encodeContext,
+  decodeContext,
+  contextToJSON,
+  contextFromJSON,
+  conformanceLevel,
+  buildContext,
+} from './context';
+export type {
+  SituationalDimensionSpec,
+  PersonalStateDimensionSpec,
+  PersonalState,
+  VCPContext,
+  VCPContextJSON,
+  ConformanceLevel,
+  EncoderInput,
+} from './context';

--- a/webmcp/src/hooks.ts
+++ b/webmcp/src/hooks.ts
@@ -1,5 +1,5 @@
 /**
- * @vcp/webmcp — VCP Hook System
+ * @creed-space/vcp-sdk — VCP Hook System
  *
  * Lightweight browser-side implementation of the VCP Hook System
  * (VCP/A Layer 4) for intercepting and modifying the constitutional

--- a/webmcp/src/index.ts
+++ b/webmcp/src/index.ts
@@ -1,11 +1,11 @@
 /**
- * @vcp/webmcp
+ * @creed-space/vcp-sdk
  *
  * Register VCP capabilities as discoverable tools for AI agents via
  * the navigator.modelContext API (Chrome 145+, W3C Draft 2026-02-10).
  *
  * Usage:
- *   import { registerVCPTools } from '@vcp/webmcp';
+ *   import { registerVCPTools } from '@creed-space/vcp-sdk';
  *   const { registered, cleanup } = await registerVCPTools({
  *     chatEndpoint: '/api/chat',
  *     tokenEncoder: encodeContextToCSM1,
@@ -101,13 +101,13 @@ export async function registerVCPTools(
 			registrations.push(reg);
 			registered.push(tool.name);
 		} catch (err) {
-			console.warn(`[@vcp/webmcp] Failed to register ${tool.name}:`, err);
+			console.warn(`[@creed-space/vcp-sdk] Failed to register ${tool.name}:`, err);
 		}
 	}
 
 	if (registered.length > 0) {
 		console.log(
-			`[@vcp/webmcp] Registered ${registered.length} tools: ${registered.join(', ')}`
+			`[@creed-space/vcp-sdk] Registered ${registered.length} tools: ${registered.join(', ')}`
 		);
 	}
 

--- a/webmcp/src/polyfill.ts
+++ b/webmcp/src/polyfill.ts
@@ -1,5 +1,5 @@
 /**
- * @vcp/webmcp — MCP-B Polyfill Loader
+ * @creed-space/vcp-sdk — MCP-B Polyfill Loader
  *
  * Conditionally loads the @mcp-b/global polyfill to populate
  * navigator.modelContext in browsers without native WebMCP support.
@@ -52,10 +52,10 @@ export async function loadPolyfillIfRequested(): Promise<boolean> {
 			});
 
 			polyfillLoaded = true;
-			console.log('[@vcp/webmcp] MCP-B polyfill loaded via ?webmcp=polyfill');
+			console.log('[@creed-space/vcp-sdk] MCP-B polyfill loaded via ?webmcp=polyfill');
 			return true;
 		} catch (err) {
-			console.warn('[@vcp/webmcp] MCP-B polyfill failed to load:', err);
+			console.warn('[@creed-space/vcp-sdk] MCP-B polyfill failed to load:', err);
 			return false;
 		}
 	})();

--- a/webmcp/src/tools.ts
+++ b/webmcp/src/tools.ts
@@ -1,5 +1,5 @@
 /**
- * @vcp/webmcp — Tool Factory
+ * @creed-space/vcp-sdk — Tool Factory
  *
  * Creates VCP tool definitions from a config object.
  * Framework-agnostic — no SvelteKit or framework-specific imports.

--- a/webmcp/src/types.ts
+++ b/webmcp/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * @vcp/webmcp — Type Definitions
+ * @creed-space/vcp-sdk — Type Definitions
  *
  * Framework-agnostic types for registering VCP tools with the
  * navigator.modelContext API (Chrome 145+, W3C Draft 2026-02-10).

--- a/webmcp/tests/context.test.ts
+++ b/webmcp/tests/context.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildContext,
+  conformanceLevel,
+  contextFromJSON,
+  contextToJSON,
+  decodeContext,
+  decodePersonalState,
+  emptyContext,
+  encodeContext,
+  encodePersonalState,
+  makePersonalState,
+  PERSONAL_SEPARATOR,
+  PERSONAL_STATE_ORDER,
+  PERSONAL_STATE_SPECS,
+  PersonalStateDimension,
+  SITUATIONAL_ORDER,
+  SITUATIONAL_SPECS,
+  SituationalDimension,
+  type VCPContext,
+} from '../src/extensions/context.js';
+
+// ───────────────────────────────────────────────────────────────────────────
+// Specs & ordering
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('SituationalDimension specs', () => {
+  it('defines 13 situational dimensions with unique positions 1..13', () => {
+    expect(SITUATIONAL_ORDER.length).toBe(13);
+    const positions = SITUATIONAL_ORDER.map((d) => SITUATIONAL_SPECS[d].position);
+    expect([...positions].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+  });
+
+  it('SYSTEM_CONTEXT is at position 9 (replacing deprecated STATE)', () => {
+    expect(SITUATIONAL_SPECS.system_context.position).toBe(9);
+    // Deprecated STATE must not appear in the enum.
+    expect((SituationalDimension as Record<string, unknown>).STATE).toBeUndefined();
+  });
+
+  it('VEP-0004 dims are positions 10-13', () => {
+    const vep = SITUATIONAL_ORDER.filter((d) => SITUATIONAL_SPECS[d].isVep0004);
+    expect(new Set(vep)).toEqual(
+      new Set(['embodiment', 'proximity', 'relationship', 'formality']),
+    );
+    for (const dim of vep) {
+      const p = SITUATIONAL_SPECS[dim].position;
+      expect(p).toBeGreaterThanOrEqual(10);
+      expect(p).toBeLessThanOrEqual(13);
+    }
+  });
+
+  it('RELATIONSHIP is free-form; TIME is not', () => {
+    expect(SITUATIONAL_SPECS.relationship.freeForm).toBe(true);
+    expect(SITUATIONAL_SPECS.time.freeForm).toBe(false);
+  });
+
+  it('CULTURE encodes communication styles, not nationalities', () => {
+    const names = new Set(Object.values(SITUATIONAL_SPECS.culture.values));
+    const forbidden = new Set(['american', 'european', 'japanese', 'global']);
+    for (const f of forbidden) expect(names.has(f)).toBe(false);
+    for (const expected of ['high_context', 'low_context', 'formal']) {
+      expect(names.has(expected)).toBe(true);
+    }
+  });
+});
+
+describe('PersonalStateDimension specs', () => {
+  it('defines 5 personal-state dims with unique positions 1..5', () => {
+    expect(PERSONAL_STATE_ORDER.length).toBe(5);
+    const positions = PERSONAL_STATE_ORDER.map((d) => PERSONAL_STATE_SPECS[d].position);
+    expect([...positions].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// PersonalState
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('PersonalState', () => {
+  it('round-trips value without intensity', () => {
+    const ps = makePersonalState('focused');
+    expect(encodePersonalState(ps)).toBe('focused');
+    expect(decodePersonalState('focused')).toEqual(ps);
+  });
+
+  it('round-trips value with intensity', () => {
+    const ps = makePersonalState('calm', 5);
+    expect(encodePersonalState(ps)).toBe('calm:5');
+    expect(decodePersonalState('calm:5')).toEqual(ps);
+  });
+
+  it('rejects out-of-range intensity', () => {
+    expect(() => makePersonalState('x', 0)).toThrow(RangeError);
+    expect(() => makePersonalState('x', 6)).toThrow(RangeError);
+  });
+
+  it('decodes a value containing a colon but non-numeric suffix as raw', () => {
+    const ps = decodePersonalState('colleague:professional');
+    // Non-numeric suffix → whole string is the value.
+    expect(ps).toEqual({ value: 'colleague:professional', intensity: null });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// encode / decode
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('VCPContext wire format', () => {
+  it('encodes a single situational dim', () => {
+    const ctx: VCPContext = {
+      situational: { time: ['🌅'] },
+      personal: {},
+    };
+    expect(encodeContext(ctx)).toBe('⏰🌅');
+  });
+
+  it('uses ‖ (U+2016) to separate situational and personal bands', () => {
+    const ctx: VCPContext = {
+      situational: { time: ['🌅'] },
+      personal: { cognitive_state: makePersonalState('focused', 4) },
+    };
+    const encoded = encodeContext(ctx);
+    expect(encoded.includes(PERSONAL_SEPARATOR)).toBe(true);
+    expect(encoded.includes('‖🧠focused:4')).toBe(true);
+  });
+
+  it('encodes a VEP-0004 RELATIONSHIP value as a free-form string', () => {
+    const ctx: VCPContext = {
+      situational: { relationship: ['colleague:professional'] },
+      personal: {},
+    };
+    expect(encodeContext(ctx)).toBe('🪢colleague:professional');
+  });
+
+  it('encodes the canonical 18-dim spec example', () => {
+    const ctx: VCPContext = {
+      situational: {
+        time: ['🌅'],
+        space: ['🏢'],
+        company: ['👔'],
+        occasion: ['💼'],
+        embodiment: ['✋'],
+        proximity: ['🤏'],
+        relationship: ['colleague:professional'],
+        formality: ['💼'],
+      },
+      personal: {
+        cognitive_state: makePersonalState('focused', 4),
+        emotional_tone: makePersonalState('calm', 5),
+        energy_level: makePersonalState('rested', 4),
+        perceived_urgency: makePersonalState('unhurried', 2),
+        body_signals: makePersonalState('neutral', 1),
+      },
+    };
+    const expected =
+      '⏰🌅|📍🏢|👥👔|🎭💼|🧍✋|↔️🤏|🪢colleague:professional|🎩💼' +
+      PERSONAL_SEPARATOR +
+      '🧠focused:4|💭calm:5|🔋rested:4|⚡unhurried:2|🩺neutral:1';
+    expect(encodeContext(ctx)).toBe(expected);
+  });
+
+  it('decodes an empty string to an empty context', () => {
+    const ctx = decodeContext('');
+    expect(ctx).toEqual(emptyContext());
+  });
+
+  it('round-trips a core situational-only context', () => {
+    const original: VCPContext = {
+      situational: { time: ['🌅'], space: ['🏡'] },
+      personal: {},
+    };
+    const decoded = decodeContext(encodeContext(original));
+    expect(decoded.situational.time).toEqual(['🌅']);
+    expect(decoded.situational.space).toEqual(['🏡']);
+  });
+
+  it('round-trips the full 18-dim context', () => {
+    const original: VCPContext = {
+      situational: {
+        time: ['🌅'],
+        embodiment: ['✋'],
+        proximity: ['🤏'],
+        relationship: ['colleague:professional'],
+        formality: ['💼'],
+      },
+      personal: {
+        cognitive_state: makePersonalState('focused', 4),
+        emotional_tone: makePersonalState('calm', 5),
+      },
+    };
+    const decoded = decodeContext(encodeContext(original));
+    expect(decoded.situational.relationship).toEqual(['colleague:professional']);
+    expect(decoded.situational.embodiment).toEqual(['✋']);
+    expect(decoded.personal.cognitive_state).toEqual({ value: 'focused', intensity: 4 });
+    expect(decoded.personal.emotional_tone).toEqual({ value: 'calm', intensity: 5 });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// JSON
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('VCPContext JSON', () => {
+  it('serialises empty context to the v3.2 nested shape', () => {
+    const data = contextToJSON(emptyContext());
+    expect(data.situational).toBeDefined();
+    expect(data.personal).toBeDefined();
+    for (const dim of SITUATIONAL_ORDER) {
+      expect(data.situational[dim]).toEqual([]);
+    }
+  });
+
+  it('round-trips through JSON', () => {
+    const original: VCPContext = {
+      situational: { time: ['🌅'], company: ['👶'] },
+      personal: { emotional_tone: makePersonalState('calm', 5) },
+    };
+    const data = contextToJSON(original);
+    const restored = contextFromJSON(data);
+    expect(restored.situational.time).toEqual(['🌅']);
+    expect(restored.situational.company).toEqual(['👶']);
+    expect(restored.personal.emotional_tone).toEqual({ value: 'calm', intensity: 5 });
+  });
+
+  it('accepts the legacy flat shape for situational-only contexts', () => {
+    const legacy = { time: ['🌅'], space: ['🏡'] };
+    const ctx = contextFromJSON(legacy);
+    expect(ctx.situational.time).toEqual(['🌅']);
+    expect(ctx.situational.space).toEqual(['🏡']);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Encoder (keyword-style builder)
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('buildContext', () => {
+  it('resolves situational names to emojis', () => {
+    const ctx = buildContext({ time: 'morning', space: 'home' });
+    expect(ctx.situational.time).toEqual(['🌅']);
+    expect(ctx.situational.space).toEqual(['🏡']);
+  });
+
+  it('encodes RELATIONSHIP as a free-form compound string', () => {
+    const ctx = buildContext({ relationship: 'colleague:professional' });
+    expect(ctx.situational.relationship).toEqual(['colleague:professional']);
+  });
+
+  it('rejects legacy nationality values on CULTURE', () => {
+    const ctx = buildContext({ culture: 'american' });
+    expect(ctx.situational.culture).toBeUndefined();
+  });
+
+  it('accepts CULTURE communication-style values', () => {
+    const ctx = buildContext({ culture: 'high_context' });
+    expect(ctx.situational.culture).toEqual(['🔇']);
+  });
+
+  it('supports personal-state inline "value:intensity" strings', () => {
+    const ctx = buildContext({ emotional_tone: 'calm:5' });
+    expect(ctx.personal.emotional_tone).toEqual({ value: 'calm', intensity: 5 });
+  });
+
+  it('supports personal-state [value, intensity] tuples', () => {
+    const ctx = buildContext({ cognitive_state: ['focused', 4] });
+    expect(ctx.personal.cognitive_state).toEqual({ value: 'focused', intensity: 4 });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Conformance classification
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('conformanceLevel', () => {
+  it('classifies a core-only context as VCP-Minimal', () => {
+    const ctx = buildContext({ time: 'morning' });
+    expect(conformanceLevel(ctx)).toBe('VCP-Minimal');
+  });
+
+  it('classifies core + personal as VCP-Standard', () => {
+    const ctx = buildContext({ time: 'morning', cognitive_state: 'focused:4' });
+    expect(conformanceLevel(ctx)).toBe('VCP-Standard');
+  });
+
+  it('classifies any VEP-0004 dim as VCP-Extended', () => {
+    const ctx = buildContext({ embodiment: 'manipulating' });
+    expect(conformanceLevel(ctx)).toBe('VCP-Extended');
+  });
+
+  it('Extended wins over Standard when both apply', () => {
+    const ctx = buildContext({
+      formality: 'professional',
+      cognitive_state: 'focused',
+    });
+    expect(conformanceLevel(ctx)).toBe('VCP-Extended');
+  });
+});
+
+// Keep reference to avoid unused-imports linter warnings in strict modes.
+void PersonalStateDimension;


### PR DESCRIPTION
## Summary

- **VCP v3.2 / VEP-0004 context layer** across all three SDKs (Python, TypeScript, Rust) — 18-dim model with 4 new situational dimensions (Embodiment, Proximity, Relationship, Formality)
- **12-vector extended conformance fixture** validating byte-for-byte parity across implementations
- **Version bump to 4.2.0** across all manifests (Python, TypeScript, Rust workspace)
- **Package rename** `@vcp/webmcp` → `@creed-space/vcp-sdk` to match publishing namespace
- **GDPR purge gaps** and `utcnow` deprecation fixes (original branch scope)
- **UVC naming sweep** (Universal Values Corpus → Universal Value Coding)

## Verification

| Lane | Result |
|------|--------|
| Python adaptation | 96/96 |
| TypeScript context + hooks | 64/64 (vitest) |
| VEP-0004 conformance fixtures | 12/12 |
| Rust vcp-core | 315/315 + 10 doc-tests |

## Test plan

- [x] Python: `pytest` — 96/96 pass
- [x] TypeScript: `vitest run` — 64/64 pass
- [x] Rust: `cargo test -p vcp-core` — 315/315 + 10 doc-tests pass
- [x] JSON schema validation (CI)
- [x] `cargo fmt` / `ruff check` clean
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)