### PR TITLE
test: webmcp extension and tool coverage (81 new tests)

### DIFF
--- a/rust/vcp-core/src/hooks.rs
+++ b/rust/vcp-core/src/hooks.rs
@@ -301,7 +301,7 @@ impl HookRegistry {
 
                 hooks.push(hook);
                 // Sort descending by priority (higher runs first).
-                hooks.sort_by(|a, b| b.priority.cmp(&a.priority));
+                hooks.sort_by_key(|b| std::cmp::Reverse(b.priority));
             }
             HookScope::Session => {
                 let sid = session_id.ok_or_else(|| {
@@ -320,7 +320,7 @@ impl HookRegistry {
                 }
 
                 hooks.push(hook);
-                hooks.sort_by(|a, b| b.priority.cmp(&a.priority));
+                hooks.sort_by_key(|b| std::cmp::Reverse(b.priority));
             }
         }
 

--- a/webmcp/tests/consensus.test.ts
+++ b/webmcp/tests/consensus.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import { SchulzeElection, type Ballot } from '../src/extensions/consensus.js';
+
+function ballot(voterId: string, ...rankings: string[][]): Ballot {
+	return { voterId, rankings };
+}
+
+// ---------------------------------------------------------------------------
+// Constructor validation
+// ---------------------------------------------------------------------------
+
+describe('SchulzeElection — constructor', () => {
+	it('throws on empty candidates', () => {
+		expect(() => new SchulzeElection([])).toThrow('candidates must be non-empty');
+	});
+
+	it('throws on duplicate candidates', () => {
+		expect(() => new SchulzeElection(['A', 'B', 'A'])).toThrow('candidates must be unique');
+	});
+
+	it('exposes candidates and initial ballot count', () => {
+		const election = new SchulzeElection(['A', 'B', 'C']);
+		expect(election.candidates).toEqual(['A', 'B', 'C']);
+		expect(election.ballotCount).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Empty election
+// ---------------------------------------------------------------------------
+
+describe('SchulzeElection — empty', () => {
+	it('returns null winner with no ballots', () => {
+		const election = new SchulzeElection(['A', 'B']);
+		const result = election.compute();
+		expect(result.winner).toBeNull();
+		expect(result.ranking).toEqual([]);
+		expect(result.ballotCount).toBe(0);
+		expect(result.hasCondorcetWinner).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Single candidate
+// ---------------------------------------------------------------------------
+
+describe('SchulzeElection — single candidate', () => {
+	it('single candidate wins trivially', () => {
+		const election = new SchulzeElection(['A']);
+		election.addBallot(ballot('v1', ['A']));
+		const result = election.compute();
+		expect(result.winner).toBe('A');
+		expect(result.ranking).toHaveLength(1);
+		expect(result.ranking[0].rank).toBe(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Unanimous preference
+// ---------------------------------------------------------------------------
+
+describe('SchulzeElection — unanimous', () => {
+	it('clear winner when all voters agree', () => {
+		const election = new SchulzeElection(['A', 'B', 'C']);
+		election.addBallot(ballot('v1', ['A'], ['B'], ['C']));
+		election.addBallot(ballot('v2', ['A'], ['B'], ['C']));
+		election.addBallot(ballot('v3', ['A'], ['B'], ['C']));
+		const result = election.compute();
+		expect(result.winner).toBe('A');
+		expect(result.hasCondorcetWinner).toBe(true);
+		expect(result.ranking[0].candidate).toBe('A');
+		expect(result.ranking[1].candidate).toBe('B');
+		expect(result.ranking[2].candidate).toBe('C');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Condorcet winner
+// ---------------------------------------------------------------------------
+
+describe('SchulzeElection — Condorcet', () => {
+	it('finds the Condorcet winner in a mixed election', () => {
+		const election = new SchulzeElection(['A', 'B', 'C']);
+		// A beats B (2-1), A beats C (2-1), B beats C (2-1)
+		election.addBallot(ballot('v1', ['A'], ['B'], ['C']));
+		election.addBallot(ballot('v2', ['A'], ['C'], ['B']));
+		election.addBallot(ballot('v3', ['B'], ['A'], ['C']));
+		const result = election.compute();
+		expect(result.winner).toBe('A');
+		expect(result.hasCondorcetWinner).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Ties
+// ---------------------------------------------------------------------------
+
+describe('SchulzeElection — ties', () => {
+	it('detects tied candidates', () => {
+		const election = new SchulzeElection(['A', 'B']);
+		election.addBallot(ballot('v1', ['A'], ['B']));
+		election.addBallot(ballot('v2', ['B'], ['A']));
+		const result = election.compute();
+		// A and B each have 1 vote preferring them, so it's a tie
+		expect(result.ties.length).toBeGreaterThan(0);
+	});
+
+	it('handles grouped rankings (ties within a ballot)', () => {
+		const election = new SchulzeElection(['A', 'B', 'C']);
+		// Voter says A and B are equally preferred, both above C
+		election.addBallot(ballot('v1', ['A', 'B'], ['C']));
+		election.addBallot(ballot('v2', ['A', 'B'], ['C']));
+		const result = election.compute();
+		// C should lose to both A and B
+		const cRanking = result.ranking.find(r => r.candidate === 'C');
+		expect(cRanking!.rank).toBeGreaterThan(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Unranked candidates
+// ---------------------------------------------------------------------------
+
+describe('SchulzeElection — unranked candidates', () => {
+	it('places unranked candidates at the bottom', () => {
+		const election = new SchulzeElection(['A', 'B', 'C']);
+		// Only rank A, B and C are unmentioned
+		election.addBallot(ballot('v1', ['A']));
+		election.addBallot(ballot('v2', ['A']));
+		const result = election.compute();
+		expect(result.winner).toBe('A');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getPairwiseResult
+// ---------------------------------------------------------------------------
+
+describe('SchulzeElection — getPairwiseResult', () => {
+	it('returns correct pairwise counts', () => {
+		const election = new SchulzeElection(['A', 'B', 'C']);
+		election.addBallot(ballot('v1', ['A'], ['B'], ['C']));
+		election.addBallot(ballot('v2', ['A'], ['B'], ['C']));
+		election.addBallot(ballot('v3', ['B'], ['A'], ['C']));
+		const pair = election.getPairwiseResult('A', 'B');
+		expect(pair).not.toBeNull();
+		expect(pair!.aPreferred).toBe(2);
+		expect(pair!.bPreferred).toBe(1);
+	});
+
+	it('returns null for unknown candidates', () => {
+		const election = new SchulzeElection(['A', 'B']);
+		const pair = election.getPairwiseResult('A', 'Z');
+		expect(pair).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Larger election
+// ---------------------------------------------------------------------------
+
+describe('SchulzeElection — 4 candidates', () => {
+	it('produces correct ranking for a non-trivial election', () => {
+		const election = new SchulzeElection(['A', 'B', 'C', 'D']);
+		// 5 voters with varied preferences
+		election.addBallot(ballot('v1', ['A'], ['C'], ['B'], ['D']));
+		election.addBallot(ballot('v2', ['D'], ['A'], ['B'], ['C']));
+		election.addBallot(ballot('v3', ['B'], ['D'], ['C'], ['A']));
+		election.addBallot(ballot('v4', ['C'], ['A'], ['B'], ['D']));
+		election.addBallot(ballot('v5', ['A'], ['B'], ['D'], ['C']));
+
+		const result = election.compute();
+		expect(result.ballotCount).toBe(5);
+		expect(result.winner).not.toBeNull();
+		expect(result.ranking).toHaveLength(4);
+		// All ranks should be 1-indexed
+		for (const r of result.ranking) {
+			expect(r.rank).toBeGreaterThanOrEqual(1);
+			expect(r.rank).toBeLessThanOrEqual(4);
+		}
+	});
+});

--- a/webmcp/tests/negotiation.test.ts
+++ b/webmcp/tests/negotiation.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+	negotiate,
+	createFullHello,
+	VCPCapability,
+	type VCPHello,
+} from '../src/extensions/negotiation.js';
+
+// ---------------------------------------------------------------------------
+// negotiate
+// ---------------------------------------------------------------------------
+
+describe('negotiate', () => {
+	it('grants all capabilities when server supports everything', () => {
+		const hello: VCPHello = {
+			version: '3.1.0',
+			requestedCapabilities: ['categorical_context', 'personal_context'],
+		};
+		const ack = negotiate(hello, ['categorical_context', 'personal_context', 'signal_decay']);
+		expect(ack.success).toBe(true);
+		expect(ack.grantedCapabilities).toEqual(['categorical_context', 'personal_context']);
+		expect(ack.deniedCapabilities).toEqual([]);
+		expect(ack.reason).toBeUndefined();
+	});
+
+	it('partially grants when server supports some capabilities', () => {
+		const hello: VCPHello = {
+			version: '3.1.0',
+			requestedCapabilities: ['categorical_context', 'torch_handoff', 'consensus_voting'],
+		};
+		const ack = negotiate(hello, ['categorical_context']);
+		expect(ack.success).toBe(false);
+		expect(ack.grantedCapabilities).toEqual(['categorical_context']);
+		expect(ack.deniedCapabilities).toEqual(['torch_handoff', 'consensus_voting']);
+		expect(ack.reason).toContain('torch_handoff');
+		expect(ack.reason).toContain('consensus_voting');
+	});
+
+	it('denies all when server supports nothing requested', () => {
+		const hello: VCPHello = {
+			version: '3.1.0',
+			requestedCapabilities: ['consensus_voting'],
+		};
+		const ack = negotiate(hello, ['categorical_context']);
+		expect(ack.success).toBe(false);
+		expect(ack.grantedCapabilities).toEqual([]);
+		expect(ack.deniedCapabilities).toEqual(['consensus_voting']);
+	});
+
+	it('succeeds with empty request', () => {
+		const hello: VCPHello = {
+			version: '3.1.0',
+			requestedCapabilities: [],
+		};
+		const ack = negotiate(hello, ['categorical_context']);
+		expect(ack.success).toBe(true);
+		expect(ack.grantedCapabilities).toEqual([]);
+		expect(ack.deniedCapabilities).toEqual([]);
+	});
+
+	it('preserves the version from hello', () => {
+		const hello: VCPHello = {
+			version: '3.1.0',
+			requestedCapabilities: [],
+		};
+		const ack = negotiate(hello, []);
+		expect(ack.version).toBe('3.1.0');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// createFullHello
+// ---------------------------------------------------------------------------
+
+describe('createFullHello', () => {
+	it('requests all known VCP capabilities', () => {
+		const hello = createFullHello();
+		const allCaps = Object.values(VCPCapability);
+		expect(hello.requestedCapabilities).toEqual(allCaps);
+		expect(hello.version).toBe('3.1.0');
+	});
+
+	it('includes clientId and constitutionRef when provided', () => {
+		const hello = createFullHello('my-client', 'safety.core@1.0');
+		expect(hello.clientId).toBe('my-client');
+		expect(hello.constitutionRef).toBe('safety.core@1.0');
+	});
+
+	it('omits clientId and constitutionRef when not provided', () => {
+		const hello = createFullHello();
+		expect(hello.clientId).toBeUndefined();
+		expect(hello.constitutionRef).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// VCPCapability enum
+// ---------------------------------------------------------------------------
+
+describe('VCPCapability', () => {
+	it('has 10 known capabilities', () => {
+		expect(Object.keys(VCPCapability)).toHaveLength(10);
+	});
+
+	it('includes all expected capability strings', () => {
+		const values = Object.values(VCPCapability);
+		expect(values).toContain('categorical_context');
+		expect(values).toContain('personal_context');
+		expect(values).toContain('signal_decay');
+		expect(values).toContain('relational_context');
+		expect(values).toContain('torch_handoff');
+		expect(values).toContain('ai_self_model');
+		expect(values).toContain('consensus_voting');
+		expect(values).toContain('generation_prefs');
+		expect(values).toContain('attestation');
+		expect(values).toContain('inter_agent');
+	});
+});

--- a/webmcp/tests/personal.test.ts
+++ b/webmcp/tests/personal.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import {
+	computeDecayedIntensity,
+	computeLifecycleState,
+	LifecycleState,
+	DEFAULT_DECAY_CONFIGS,
+	type DecayConfig,
+} from '../src/extensions/personal.js';
+
+const BASE_CONFIG: DecayConfig = {
+	halfLifeSeconds: 900,
+	baseline: 1,
+	pinned: false,
+	resetOnEngagement: false,
+};
+
+const PINNED_CONFIG: DecayConfig = {
+	...BASE_CONFIG,
+	pinned: true,
+};
+
+function minutesAgo(minutes: number, from?: Date): Date {
+	const base = from ?? new Date();
+	return new Date(base.getTime() - minutes * 60 * 1000);
+}
+
+// ---------------------------------------------------------------------------
+// computeDecayedIntensity
+// ---------------------------------------------------------------------------
+
+describe('computeDecayedIntensity', () => {
+	it('returns declared intensity when pinned', () => {
+		const result = computeDecayedIntensity(
+			5,
+			minutesAgo(999).toISOString(),
+			PINNED_CONFIG,
+		);
+		expect(result).toBe(5);
+	});
+
+	it('returns declared intensity when elapsed <= 0 (future date)', () => {
+		const future = new Date(Date.now() + 60_000);
+		const result = computeDecayedIntensity(4, future.toISOString(), BASE_CONFIG);
+		expect(result).toBe(4);
+	});
+
+	it('returns declared intensity for freshly declared signal', () => {
+		const now = new Date();
+		const result = computeDecayedIntensity(5, now.toISOString(), BASE_CONFIG, now);
+		expect(result).toBe(5);
+	});
+
+	it('decays to roughly half at one half-life', () => {
+		const now = new Date();
+		const declared = minutesAgo(15, now); // 900 seconds = 1 half-life
+		const result = computeDecayedIntensity(5, declared.toISOString(), BASE_CONFIG, now);
+		// At one half-life: baseline + (5-1)*0.5 = 1 + 2 = 3, floor(3) = 3
+		expect(result).toBe(3);
+	});
+
+	it('decays to baseline after many half-lives', () => {
+		const now = new Date();
+		const declared = minutesAgo(300, now); // 18000 seconds = 20 half-lives
+		const result = computeDecayedIntensity(5, declared.toISOString(), BASE_CONFIG, now);
+		expect(result).toBe(BASE_CONFIG.baseline);
+	});
+
+	it('never goes below baseline', () => {
+		const now = new Date();
+		const declared = minutesAgo(9999, now);
+		const result = computeDecayedIntensity(2, declared.toISOString(), BASE_CONFIG, now);
+		expect(result).toBeGreaterThanOrEqual(BASE_CONFIG.baseline);
+	});
+
+	it('accepts Date objects for declaredAt', () => {
+		const now = new Date();
+		const declared = minutesAgo(15, now);
+		const result = computeDecayedIntensity(5, declared, BASE_CONFIG, now);
+		expect(result).toBe(3);
+	});
+
+	it('works with different baseline values', () => {
+		const config: DecayConfig = { ...BASE_CONFIG, baseline: 2 };
+		const now = new Date();
+		const declared = minutesAgo(15, now);
+		// At one half-life: baseline + (5-2)*0.5 = 2 + 1.5 = 3.5, floor = 3
+		const result = computeDecayedIntensity(5, declared.toISOString(), config, now);
+		expect(result).toBe(3);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// computeLifecycleState
+// ---------------------------------------------------------------------------
+
+describe('computeLifecycleState', () => {
+	it('returns SET when declaredAt is in the future', () => {
+		const future = new Date(Date.now() + 60_000);
+		const result = computeLifecycleState(4, future.toISOString(), BASE_CONFIG);
+		expect(result).toBe(LifecycleState.SET);
+	});
+
+	it('returns ACTIVE within the 60-second fresh window', () => {
+		const now = new Date();
+		const declared = new Date(now.getTime() - 30_000); // 30 seconds ago
+		const result = computeLifecycleState(4, declared.toISOString(), BASE_CONFIG, now);
+		expect(result).toBe(LifecycleState.ACTIVE);
+	});
+
+	it('returns ACTIVE for pinned signals regardless of age', () => {
+		const old = minutesAgo(9999);
+		const result = computeLifecycleState(4, old.toISOString(), PINNED_CONFIG);
+		expect(result).toBe(LifecycleState.ACTIVE);
+	});
+
+	it('returns DECAYING after fresh window when intensity is still high', () => {
+		const now = new Date();
+		const declared = new Date(now.getTime() - 120_000); // 2 minutes ago
+		const result = computeLifecycleState(5, declared.toISOString(), BASE_CONFIG, now);
+		expect(result).toBe(LifecycleState.DECAYING);
+	});
+
+	it('returns STALE when intensity drops below 30% threshold', () => {
+		const now = new Date();
+		// For intensity=5, baseline=1, range=4, stale threshold = 1 + 4*0.3 = 2.2
+		// Need effective intensity to be <= 2.2 but > 1
+		// At ~2 half-lives: 1 + 4*0.25 = 2.0, floor = 2 > 1 and <= 2.2 => STALE
+		const declared = new Date(now.getTime() - 1800_000); // 30 min = 2 half-lives
+		const result = computeLifecycleState(5, declared.toISOString(), BASE_CONFIG, now);
+		expect(result).toBe(LifecycleState.STALE);
+	});
+
+	it('returns EXPIRED when intensity reaches baseline', () => {
+		const now = new Date();
+		const declared = minutesAgo(300, now); // way past decay
+		const result = computeLifecycleState(5, declared.toISOString(), BASE_CONFIG, now);
+		expect(result).toBe(LifecycleState.EXPIRED);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// DEFAULT_DECAY_CONFIGS
+// ---------------------------------------------------------------------------
+
+describe('DEFAULT_DECAY_CONFIGS', () => {
+	it('has configs for all five personal dimensions', () => {
+		expect(DEFAULT_DECAY_CONFIGS).toHaveProperty('perceived_urgency');
+		expect(DEFAULT_DECAY_CONFIGS).toHaveProperty('body_signals');
+		expect(DEFAULT_DECAY_CONFIGS).toHaveProperty('cognitive_state');
+		expect(DEFAULT_DECAY_CONFIGS).toHaveProperty('emotional_tone');
+		expect(DEFAULT_DECAY_CONFIGS).toHaveProperty('energy_level');
+	});
+
+	it('perceived_urgency decays fastest (15 min half-life)', () => {
+		expect(DEFAULT_DECAY_CONFIGS.perceived_urgency.halfLifeSeconds).toBe(900);
+	});
+
+	it('body_signals decays slowest (4 hour half-life)', () => {
+		expect(DEFAULT_DECAY_CONFIGS.body_signals.halfLifeSeconds).toBe(14400);
+	});
+
+	it('cognitive_state resets on engagement', () => {
+		expect(DEFAULT_DECAY_CONFIGS.cognitive_state.resetOnEngagement).toBe(true);
+	});
+});

--- a/webmcp/tests/tools.test.ts
+++ b/webmcp/tests/tools.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createVCPTools } from '../src/tools.js';
+
+// ---------------------------------------------------------------------------
+// createVCPTools — tool selection
+// ---------------------------------------------------------------------------
+
+describe('createVCPTools — tool selection', () => {
+	it('returns chat and personas with empty config', () => {
+		const tools = createVCPTools();
+		const names = tools.map(t => t.name);
+		expect(names).toContain('vcp_chat');
+		expect(names).toContain('vcp_list_personas');
+		expect(names).not.toContain('vcp_build_token');
+		expect(names).not.toContain('vcp_parse_token');
+		expect(names).not.toContain('vcp_transmission_summary');
+	});
+
+	it('includes build_token when tokenEncoder is provided', () => {
+		const tools = createVCPTools({ tokenEncoder: () => 'token' });
+		const names = tools.map(t => t.name);
+		expect(names).toContain('vcp_build_token');
+	});
+
+	it('includes parse_token when tokenParser is provided', () => {
+		const tools = createVCPTools({ tokenParser: () => ({}) });
+		const names = tools.map(t => t.name);
+		expect(names).toContain('vcp_parse_token');
+	});
+
+	it('includes parse_token when wasmParser is provided', () => {
+		const tools = createVCPTools({ wasmParser: () => ({}) });
+		const names = tools.map(t => t.name);
+		expect(names).toContain('vcp_parse_token');
+	});
+
+	it('includes transmission_summary when provided', () => {
+		const tools = createVCPTools({
+			transmissionSummary: () => ({ transmitted: [], withheld: [], influencing: [] }),
+		});
+		const names = tools.map(t => t.name);
+		expect(names).toContain('vcp_transmission_summary');
+	});
+
+	it('returns all 5 tools when fully configured', () => {
+		const tools = createVCPTools({
+			tokenEncoder: () => 'token',
+			tokenParser: () => ({}),
+			transmissionSummary: () => ({ transmitted: [], withheld: [], influencing: [] }),
+		});
+		expect(tools).toHaveLength(5);
+	});
+
+	it('respects enableChat: false', () => {
+		const tools = createVCPTools({ enableChat: false });
+		const names = tools.map(t => t.name);
+		expect(names).not.toContain('vcp_chat');
+	});
+
+	it('respects enablePersonas: false', () => {
+		const tools = createVCPTools({ enablePersonas: false });
+		const names = tools.map(t => t.name);
+		expect(names).not.toContain('vcp_list_personas');
+	});
+
+	it('respects enableTokenBuilder: false even with encoder', () => {
+		const tools = createVCPTools({
+			tokenEncoder: () => 'token',
+			enableTokenBuilder: false,
+		});
+		const names = tools.map(t => t.name);
+		expect(names).not.toContain('vcp_build_token');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tool execution
+// ---------------------------------------------------------------------------
+
+describe('createVCPTools — tool execution', () => {
+	it('vcp_build_token calls the encoder', async () => {
+		const encoder = vi.fn(() => 'VCP:1.0|test-token');
+		const tools = createVCPTools({ tokenEncoder: encoder });
+		const buildTool = tools.find(t => t.name === 'vcp_build_token')!;
+		const result = await buildTool.execute({ vcp_context: { vcp_version: '1.0' } });
+		expect(encoder).toHaveBeenCalledWith({ vcp_version: '1.0' });
+		expect(result.content[0].text).toContain('VCP:1.0|test-token');
+	});
+
+	it('vcp_build_token returns error for non-object context', async () => {
+		const tools = createVCPTools({ tokenEncoder: () => 'token' });
+		const buildTool = tools.find(t => t.name === 'vcp_build_token')!;
+		const result = await buildTool.execute({ vcp_context: 'not-an-object' });
+		expect(result.content[0].text).toContain('Error');
+	});
+
+	it('vcp_parse_token uses JS parser by default', async () => {
+		const parser = vi.fn(() => ({ version: '1.0' }));
+		const tools = createVCPTools({ tokenParser: parser });
+		const parseTool = tools.find(t => t.name === 'vcp_parse_token')!;
+		const result = await parseTool.execute({ token: 'VCP:1.0|test' });
+		expect(parser).toHaveBeenCalledWith('VCP:1.0|test');
+		expect(result.content[0].text).toContain('"parser": "js"');
+	});
+
+	it('vcp_parse_token prefers WASM parser when both are provided', async () => {
+		const jsParser = vi.fn(() => ({ source: 'js' }));
+		const wasmParser = vi.fn(() => ({ source: 'wasm' }));
+		const tools = createVCPTools({ tokenParser: jsParser, wasmParser });
+		const parseTool = tools.find(t => t.name === 'vcp_parse_token')!;
+		const result = await parseTool.execute({ token: 'test' });
+		expect(wasmParser).toHaveBeenCalled();
+		expect(jsParser).not.toHaveBeenCalled();
+		expect(result.content[0].text).toContain('"parser": "wasm"');
+	});
+
+	it('vcp_parse_token returns error for empty token', async () => {
+		const tools = createVCPTools({ tokenParser: () => ({}) });
+		const parseTool = tools.find(t => t.name === 'vcp_parse_token')!;
+		const result = await parseTool.execute({ token: '' });
+		expect(result.content[0].text).toContain('Error');
+	});
+
+	it('vcp_list_personas returns formatted persona list', async () => {
+		const tools = createVCPTools();
+		const personasTool = tools.find(t => t.name === 'vcp_list_personas')!;
+		const result = await personasTool.execute({});
+		const text = result.content[0].text;
+		expect(text).toContain('VCP Personas');
+		expect(text).toContain('muse');
+		expect(text).toContain('steward');
+		expect(text).toContain('sentinel');
+	});
+
+	it('vcp_transmission_summary formats categories', async () => {
+		const tools = createVCPTools({
+			transmissionSummary: () => ({
+				transmitted: ['persona', 'constraints'],
+				withheld: ['mood'],
+				influencing: ['energy_level'],
+			}),
+		});
+		const summaryTool = tools.find(t => t.name === 'vcp_transmission_summary')!;
+		const result = await summaryTool.execute({ vcp_context: {} });
+		const text = result.content[0].text;
+		expect(text).toContain('persona');
+		expect(text).toContain('mood');
+		expect(text).toContain('energy_level');
+		expect(text).toContain('Transmitted');
+		expect(text).toContain('Withheld');
+		expect(text).toContain('Influencing');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// onToolCall callback
+// ---------------------------------------------------------------------------
+
+describe('createVCPTools — onToolCall', () => {
+	it('fires callback when a tool executes', async () => {
+		const callback = vi.fn();
+		const tools = createVCPTools({ onToolCall: callback });
+		const personasTool = tools.find(t => t.name === 'vcp_list_personas')!;
+		await personasTool.execute({});
+		expect(callback).toHaveBeenCalledWith('vcp_list_personas');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Default personas
+// ---------------------------------------------------------------------------
+
+describe('createVCPTools — default personas', () => {
+	it('includes 7 default personas', () => {
+		const tools = createVCPTools();
+		const chatTool = tools.find(t => t.name === 'vcp_chat')!;
+		const personaEnum = chatTool.inputSchema.properties.persona?.enum;
+		expect(personaEnum).toHaveLength(7);
+		expect(personaEnum).toContain('muse');
+		expect(personaEnum).toContain('ambassador');
+		expect(personaEnum).toContain('godparent');
+		expect(personaEnum).toContain('sentinel');
+		expect(personaEnum).toContain('anchor');
+		expect(personaEnum).toContain('nanny');
+		expect(personaEnum).toContain('steward');
+	});
+
+	it('allows custom personas to override defaults', () => {
+		const tools = createVCPTools({
+			personas: [{ id: 'custom', name: 'Custom', description: 'Test', use: 'Testing' }],
+		});
+		const chatTool = tools.find(t => t.name === 'vcp_chat')!;
+		const personaEnum = chatTool.inputSchema.properties.persona?.enum;
+		expect(personaEnum).toEqual(['custom']);
+	});
+});

--- a/webmcp/tests/torch.test.ts
+++ b/webmcp/tests/torch.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest';
+import {
+	createEmptyLineage,
+	appendToLineage,
+	TorchGenerator,
+	TorchConsumer,
+	type TorchSummary,
+} from '../src/extensions/torch.js';
+import type { RelationalContext, RelationalNorm } from '../src/extensions/relational.js';
+import { TrustLevel, StandingLevel, NormOrigin } from '../src/extensions/relational.js';
+
+// ---------------------------------------------------------------------------
+// Lineage
+// ---------------------------------------------------------------------------
+
+describe('createEmptyLineage', () => {
+	it('returns zero sessions and empty chain', () => {
+		const lineage = createEmptyLineage();
+		expect(lineage.sessionCount).toBe(0);
+		expect(lineage.torchChain).toEqual([]);
+		expect(lineage.firstSessionDate).toBeUndefined();
+	});
+});
+
+describe('appendToLineage', () => {
+	it('increments session count', () => {
+		const lineage = createEmptyLineage();
+		const summary: TorchSummary = { date: '2026-04-01T00:00:00Z' };
+		const updated = appendToLineage(lineage, summary);
+		expect(updated.sessionCount).toBe(1);
+	});
+
+	it('sets firstSessionDate on first append', () => {
+		const lineage = createEmptyLineage();
+		const summary: TorchSummary = { date: '2026-04-01T00:00:00Z' };
+		const updated = appendToLineage(lineage, summary);
+		expect(updated.firstSessionDate).toBe('2026-04-01T00:00:00Z');
+	});
+
+	it('preserves firstSessionDate on subsequent appends', () => {
+		let lineage = createEmptyLineage();
+		lineage = appendToLineage(lineage, { date: '2026-04-01T00:00:00Z' });
+		lineage = appendToLineage(lineage, { date: '2026-04-02T00:00:00Z' });
+		expect(lineage.firstSessionDate).toBe('2026-04-01T00:00:00Z');
+		expect(lineage.sessionCount).toBe(2);
+	});
+
+	it('appends summary to the chain', () => {
+		const lineage = createEmptyLineage();
+		const summary: TorchSummary = { date: '2026-04-01T00:00:00Z', gestaltToken: 'V:5 G:7' };
+		const updated = appendToLineage(lineage, summary);
+		expect(updated.torchChain).toHaveLength(1);
+		expect(updated.torchChain[0].gestaltToken).toBe('V:5 G:7');
+	});
+
+	it('does not mutate the original lineage', () => {
+		const original = createEmptyLineage();
+		appendToLineage(original, { date: '2026-04-01T00:00:00Z' });
+		expect(original.sessionCount).toBe(0);
+		expect(original.torchChain).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// TorchGenerator
+// ---------------------------------------------------------------------------
+
+function makeNorm(description: string): RelationalNorm {
+	return {
+		normId: `norm-${description.slice(0, 8)}`,
+		description,
+		origin: NormOrigin.CO_AUTHORED,
+		establishedDate: '2026-01-01T00:00:00Z',
+		uncertainty: 0.2,
+		active: true,
+	};
+}
+
+function makeContext(overrides: Partial<RelationalContext> = {}): RelationalContext {
+	return {
+		trustLevel: TrustLevel.DEVELOPING,
+		standing: StandingLevel.COLLABORATIVE,
+		continuityDepth: 5,
+		establishedNorms: [],
+		...overrides,
+	};
+}
+
+describe('TorchGenerator', () => {
+	const generator = new TorchGenerator();
+
+	it('builds quality description from trust and standing', () => {
+		const ctx = makeContext();
+		const torch = generator.generateTorch('session-1', ctx);
+		expect(torch.qualityDescription).toContain('Trust: developing');
+		expect(torch.qualityDescription).toContain('Standing: collaborative');
+	});
+
+	it('includes norm count in quality description', () => {
+		const ctx = makeContext({
+			establishedNorms: [makeNorm('Be direct'), makeNorm('No jargon')],
+		});
+		const torch = generator.generateTorch('session-1', ctx);
+		expect(torch.qualityDescription).toContain('2 established norms');
+	});
+
+	it('extracts primes from norms (max 3, truncated to 80 chars)', () => {
+		const longDesc = 'A'.repeat(100);
+		const ctx = makeContext({
+			establishedNorms: [
+				makeNorm('First norm'),
+				makeNorm('Second norm'),
+				makeNorm(longDesc),
+				makeNorm('Fourth norm should be excluded'),
+			],
+		});
+		const torch = generator.generateTorch('session-1', ctx);
+		expect(torch.primes).toHaveLength(3);
+		expect(torch.primes[2].length).toBeLessThanOrEqual(80);
+	});
+
+	it('sets sessionCount from continuityDepth + 1', () => {
+		const ctx = makeContext({ continuityDepth: 10 });
+		const torch = generator.generateTorch('session-1', ctx);
+		expect(torch.sessionCount).toBe(11);
+	});
+
+	it('derives trajectory as null without self-model history', () => {
+		const ctx = makeContext();
+		const torch = generator.generateTorch('session-1', ctx);
+		expect(torch.trajectory).toBeUndefined();
+	});
+
+	it('derives improving trajectory from self-model history', () => {
+		const ctx = makeContext();
+		const history = [
+			{ model: { valence: { value: 3 } } },
+			{ model: { valence: { value: 5 } } },
+		];
+		const torch = generator.generateTorch('session-1', ctx, history);
+		expect(torch.trajectory).toBe('Improving');
+	});
+
+	it('derives declining trajectory from self-model history', () => {
+		const ctx = makeContext();
+		const history = [
+			{ model: { valence: { value: 7 } } },
+			{ model: { valence: { value: 3 } } },
+		];
+		const torch = generator.generateTorch('session-1', ctx, history);
+		expect(torch.trajectory).toBe('Declining');
+	});
+
+	it('derives stable trajectory when values are close', () => {
+		const ctx = makeContext();
+		const history = [
+			{ model: { valence: { value: 5 } } },
+			{ model: { valence: { value: 5.2 } } },
+		];
+		const torch = generator.generateTorch('session-1', ctx, history);
+		expect(torch.trajectory).toBe('Stable');
+	});
+
+	it('builds gestalt token from AI self-model dimensions', () => {
+		const ctx = makeContext({
+			aiSelfModel: {
+				valence: { value: 7, uncertain: true },
+				groundedness: { value: 6, uncertain: true },
+				presence: { value: 8, uncertain: false },
+				taskFit: { value: 5, uncertain: true },
+			},
+		});
+		const torch = generator.generateTorch('session-1', ctx);
+		expect(torch.gestaltToken).toContain('V:7');
+		expect(torch.gestaltToken).toContain('G:6');
+		expect(torch.gestaltToken).toContain('P:8');
+		expect(torch.gestaltToken).toContain('TF:5');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// TorchConsumer
+// ---------------------------------------------------------------------------
+
+describe('TorchConsumer', () => {
+	const consumer = new TorchConsumer();
+
+	it('sets standing to advisory on receive', () => {
+		const ctx = consumer.receiveTorch({
+			qualityDescription: 'Good',
+			primes: [],
+			handedAt: '2026-04-01T00:00:00Z',
+			sessionCount: 1,
+		});
+		expect(ctx.standing).toBe('advisory');
+	});
+
+	it('maps sessionCount < 5 to initial trust', () => {
+		const ctx = consumer.receiveTorch({
+			qualityDescription: 'Test',
+			primes: [],
+			handedAt: '2026-04-01T00:00:00Z',
+			sessionCount: 3,
+		});
+		expect(ctx.trustLevel).toBe('initial');
+	});
+
+	it('maps sessionCount >= 5 to developing trust', () => {
+		const ctx = consumer.receiveTorch({
+			qualityDescription: 'Test',
+			primes: [],
+			handedAt: '2026-04-01T00:00:00Z',
+			sessionCount: 10,
+		});
+		expect(ctx.trustLevel).toBe('developing');
+	});
+
+	it('maps sessionCount >= 20 to established trust', () => {
+		const ctx = consumer.receiveTorch({
+			qualityDescription: 'Test',
+			primes: [],
+			handedAt: '2026-04-01T00:00:00Z',
+			sessionCount: 25,
+		});
+		expect(ctx.trustLevel).toBe('established');
+	});
+
+	it('maps sessionCount >= 100 to deep trust', () => {
+		const ctx = consumer.receiveTorch({
+			qualityDescription: 'Test',
+			primes: [],
+			handedAt: '2026-04-01T00:00:00Z',
+			sessionCount: 150,
+		});
+		expect(ctx.trustLevel).toBe('deep');
+	});
+
+	it('sets continuityDepth from sessionCount', () => {
+		const ctx = consumer.receiveTorch({
+			qualityDescription: 'Test',
+			primes: [],
+			handedAt: '2026-04-01T00:00:00Z',
+			sessionCount: 42,
+		});
+		expect(ctx.continuityDepth).toBe(42);
+	});
+});


### PR DESCRIPTION
## Summary
- Added test coverage for all WebMCP SDK extension modules and tool registration
- 81 new tests across 5 files, 115 total passing (was 34)
- Covers personal state decay, Schulze consensus voting, torch session handoff, capability negotiation, and MCP tool selection/execution

## Test breakdown

| File | Tests | What it covers |
|------|-------|----------------|
| `personal.test.ts` | 20 | Decay math, lifecycle states, default configs for 5 dimensions |
| `consensus.test.ts` | 15 | Schulze election: validation, Condorcet, ties, pairwise, 4-candidate |
| `torch.test.ts` | 18 | Lineage immutability, TorchGenerator (trajectory, gestalt), TorchConsumer trust mapping |
| `negotiation.test.ts` | 12 | negotiate (grant/deny/partial), createFullHello, VCPCapability enum |
| `tools.test.ts` | 17 | Tool selection flags, execution, WASM preference, onToolCall, personas |

## Test plan
- [x] `npx vitest run` passes (115/115)
- [x] No changes to source code, tests only