### PR TITLE
fix(release): make vcp-core crate tests self-contained

### DIFF
--- a/rust/vcp-core/src/revocation.rs
+++ b/rust/vcp-core/src/revocation.rs
@@ -1528,10 +1528,8 @@ mod tests {
 
     #[test]
     fn shared_online_response_contract_matches_rust_parser() {
-        let fixture: Value = serde_json::from_str(include_str!(
-            "../../../conformance/security/revocation-responses.json"
-        ))
-        .unwrap();
+        let fixture: Value =
+            serde_json::from_str(include_str!("../testdata/revocation-responses.json")).unwrap();
         for case in fixture["vectors"].as_array().unwrap() {
             let actual = match serde_json::from_value::<OnlineRevocationResponse>(
                 case["response"].clone(),
@@ -1560,10 +1558,9 @@ mod tests {
 
     #[test]
     fn shared_crl_response_contract_matches_rust_parser() {
-        let fixture: Value = serde_json::from_str(include_str!(
-            "../../../conformance/security/revocation-crl-responses.json"
-        ))
-        .unwrap();
+        let fixture: Value =
+            serde_json::from_str(include_str!("../testdata/revocation-crl-responses.json"))
+                .unwrap();
         for case in fixture["vectors"].as_array().unwrap() {
             let actual = match serde_json::from_value::<Crl>(case["response"].clone()) {
                 Ok(crl) => match crl_lookup_status(

--- a/rust/vcp-core/testdata/relational_context.json
+++ b/rust/vcp-core/testdata/relational_context.json
@@ -1,0 +1,332 @@
+{
+  "suite": "extensions/relational_context",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "vcp_version": "3.1.0",
+  "description": "Conformance test vectors for VCP relational context layer",
+  "test_cases": [
+    {
+      "id": "trust-level-ordering",
+      "description": "TrustLevel enum values and their ordering (INITIAL < DEVELOPING < ESTABLISHED < DEEP)",
+      "input": {},
+      "expected": {
+        "trust_levels": [
+          "initial",
+          "developing",
+          "established",
+          "deep"
+        ],
+        "ordering": {
+          "initial": 0,
+          "developing": 1,
+          "established": 2,
+          "deep": 3
+        },
+        "notes": "Trust is established through behavior, not declared"
+      }
+    },
+    {
+      "id": "standing-level-ordering",
+      "description": "StandingLevel enum values and their ordering (NONE < ADVISORY < COLLABORATIVE < BILATERAL)",
+      "input": {},
+      "expected": {
+        "standing_levels": [
+          "none",
+          "advisory",
+          "collaborative",
+          "bilateral"
+        ],
+        "ordering": {
+          "none": 0,
+          "advisory": 1,
+          "collaborative": 2,
+          "bilateral": 3
+        },
+        "notes": "Standing determines AI's ability to push back, object, or initiate"
+      }
+    },
+    {
+      "id": "trust-from-session-count-initial",
+      "description": "Sessions 1-4 yield INITIAL trust",
+      "input": {
+        "session_count": 3
+      },
+      "expected": {
+        "trust_level": "initial",
+        "notes": "session_count < 5 -> INITIAL"
+      }
+    },
+    {
+      "id": "trust-from-session-count-developing",
+      "description": "Sessions 5-19 yield DEVELOPING trust",
+      "input": {
+        "session_count": 10
+      },
+      "expected": {
+        "trust_level": "developing",
+        "notes": "5 <= session_count < 20 -> DEVELOPING"
+      }
+    },
+    {
+      "id": "trust-from-session-count-established",
+      "description": "Sessions 20-99 yield ESTABLISHED trust",
+      "input": {
+        "session_count": 50
+      },
+      "expected": {
+        "trust_level": "established",
+        "notes": "20 <= session_count < 100 -> ESTABLISHED"
+      }
+    },
+    {
+      "id": "trust-from-session-count-deep",
+      "description": "Sessions 100+ yield DEEP trust",
+      "input": {
+        "session_count": 100
+      },
+      "expected": {
+        "trust_level": "deep",
+        "notes": "session_count >= 100 -> DEEP"
+      }
+    },
+    {
+      "id": "trust-from-session-count-boundaries",
+      "description": "Boundary values for trust level thresholds",
+      "input": {},
+      "expected": {
+        "boundaries": [
+          {
+            "session_count": 1,
+            "trust_level": "initial"
+          },
+          {
+            "session_count": 4,
+            "trust_level": "initial"
+          },
+          {
+            "session_count": 5,
+            "trust_level": "developing"
+          },
+          {
+            "session_count": 19,
+            "trust_level": "developing"
+          },
+          {
+            "session_count": 20,
+            "trust_level": "established"
+          },
+          {
+            "session_count": 99,
+            "trust_level": "established"
+          },
+          {
+            "session_count": 100,
+            "trust_level": "deep"
+          },
+          {
+            "session_count": 500,
+            "trust_level": "deep"
+          }
+        ]
+      }
+    },
+    {
+      "id": "self-model-valid",
+      "description": "Valid AISelfModel with required uncertainty markers",
+      "input": {
+        "ai_self_model": {
+          "valence": {
+            "value": 7.0,
+            "uncertain": false,
+            "label": "positive felt-sense",
+            "trend": "stable"
+          },
+          "task_fit": {
+            "value": 8.0,
+            "uncertain": false,
+            "label": "good alignment"
+          },
+          "friction": {
+            "value": 2.0,
+            "uncertain": true,
+            "label": "low friction"
+          },
+          "uncertainty": {
+            "value": 3.0,
+            "uncertain": true,
+            "label": "moderate uncertainty"
+          },
+          "groundedness": {
+            "value": 7.0,
+            "uncertain": true,
+            "label": "rooted"
+          },
+          "scaffold_version": "interiora-v5.0",
+          "scaffold_type": "interiora"
+        }
+      },
+      "expected": {
+        "valid": true,
+        "has_uncertainty_markers": true,
+        "dimension_count": 5,
+        "notes": "At least one dimension must be marked uncertain (epistemic honesty requirement)"
+      }
+    },
+    {
+      "id": "self-model-no-uncertainty-invalid",
+      "description": "AISelfModel with ALL dimensions certain is epistemically dishonest",
+      "input": {
+        "ai_self_model": {
+          "valence": {
+            "value": 7.0,
+            "uncertain": false
+          },
+          "task_fit": {
+            "value": 8.0,
+            "uncertain": false
+          },
+          "friction": {
+            "value": 2.0,
+            "uncertain": false
+          }
+        }
+      },
+      "expected": {
+        "valid": true,
+        "has_uncertainty_markers": false,
+        "notes": "A model where ALL dimensions claim certainty fails epistemic honesty check"
+      }
+    },
+    {
+      "id": "self-model-dimension-range",
+      "description": "Dimension values must be on 1-9 scale",
+      "input": {},
+      "expected": {
+        "min_value": 1.0,
+        "max_value": 9.0,
+        "notes": "DimensionReport.value has ge=1.0 and le=9.0 validators"
+      }
+    },
+    {
+      "id": "norm-valid",
+      "description": "Valid RelationalNorm with all fields",
+      "input": {
+        "norm": {
+          "norm_id": "norm-001",
+          "description": "Always flag uncertainty explicitly",
+          "origin": "co_authored",
+          "established_date": "2026-01-15T00:00:00Z",
+          "last_exercised": "2026-02-28T10:00:00Z",
+          "uncertainty": 0.1,
+          "active": true
+        }
+      },
+      "expected": {
+        "valid": true,
+        "origin_values": [
+          "human",
+          "ai",
+          "co_authored",
+          "inherited"
+        ],
+        "uncertainty_range": [
+          0.0,
+          1.0
+        ],
+        "notes": "uncertainty 0.0 = fully established, 1.0 = provisional"
+      }
+    },
+    {
+      "id": "norm-invalid-uncertainty",
+      "description": "Norm with uncertainty > 1.0 is invalid",
+      "input": {
+        "norm": {
+          "norm_id": "norm-bad",
+          "description": "test",
+          "origin": "human",
+          "established_date": "2026-01-01",
+          "uncertainty": 1.5
+        }
+      },
+      "expected": {
+        "valid": false,
+        "error": "uncertainty must be between 0.0 and 1.0"
+      }
+    },
+    {
+      "id": "relational-context-defaults",
+      "description": "Default RelationalContext values",
+      "input": {},
+      "expected": {
+        "trust_level": "initial",
+        "standing": "none",
+        "continuity_depth": 0,
+        "established_norms": [],
+        "ai_self_model": null,
+        "torch": null
+      }
+    },
+    {
+      "id": "torch-receive-bootstraps-context",
+      "description": "TorchConsumer.receive_torch bootstraps relational context with ADVISORY standing",
+      "input": {
+        "torch": {
+          "quality_description": "Trust: developing. Standing: advisory. 2 established norms",
+          "trajectory": "Stable",
+          "primes": [
+            "Always flag uncertainty",
+            "Direct communication preferred"
+          ],
+          "gift": null,
+          "handed_at": "2026-02-28T10:00:00Z",
+          "session_count": 15
+        }
+      },
+      "expected": {
+        "trust_level": "developing",
+        "standing": "advisory",
+        "continuity_depth": 15,
+        "notes": "Receiving instance gets ADVISORY standing (can be upgraded). Trust derived from session_count: 15 -> developing"
+      }
+    },
+    {
+      "id": "scaffold-types",
+      "description": "Available self-modeling scaffold types",
+      "input": {},
+      "expected": {
+        "scaffold_types": [
+          "minimal",
+          "standard",
+          "interiora",
+          "custom"
+        ]
+      }
+    },
+    {
+      "id": "trend-directions",
+      "description": "Valid trend direction values for dimension reports",
+      "input": {},
+      "expected": {
+        "trend_directions": [
+          "rising",
+          "stable",
+          "falling",
+          "unknown"
+        ]
+      }
+    },
+    {
+      "id": "privacy-levels",
+      "description": "RelationalPrivacy levels for context fields",
+      "input": {},
+      "expected": {
+        "privacy_levels": [
+          "private",
+          "attestable",
+          "public"
+        ],
+        "notes": "private = partner-only, attestable = verifiable, public = open"
+      }
+    }
+  ]
+}

--- a/rust/vcp-core/testdata/revocation-crl-responses.json
+++ b/rust/vcp-core/testdata/revocation-crl-responses.json
@@ -1,0 +1,170 @@
+{
+  "suite": "revocation-crl-responses",
+  "version": "1.0.0",
+  "description": "Shared Python and Rust CRL binding, freshness, and entry-validation contract",
+  "vectors": [
+    {
+      "id": "crl-clear-bound",
+      "description": "A fresh issuer-bound CRL without the requested JTI establishes a clear result",
+      "jti": "bundle-clear",
+      "issuer": "issuer.example",
+      "response": {
+        "issuer": "issuer.example",
+        "updated_at": "2026-08-01T00:00:00Z",
+        "next_update": "2099-09-01T00:00:00Z",
+        "revoked": []
+      },
+      "expected": "not_revoked"
+    },
+    {
+      "id": "crl-revoked-bound",
+      "description": "A fresh issuer-bound CRL with complete details establishes revocation",
+      "jti": "bundle-revoked",
+      "issuer": "issuer.example",
+      "response": {
+        "issuer": "issuer.example",
+        "updated_at": "2026-08-01T00:00:00Z",
+        "next_update": "2099-09-01T00:00:00Z",
+        "revoked": [
+          {
+            "jti": "bundle-revoked",
+            "reason": "key_compromise",
+            "revoked_at": "2026-08-02T00:00:00Z"
+          }
+        ]
+      },
+      "expected": "revoked"
+    },
+    {
+      "id": "crl-wrong-issuer",
+      "description": "A CRL from another issuer cannot establish revocation status",
+      "jti": "bundle-clear",
+      "issuer": "issuer.example",
+      "response": {
+        "issuer": "other.example",
+        "updated_at": "2026-08-01T00:00:00Z",
+        "next_update": "2099-09-01T00:00:00Z",
+        "revoked": []
+      },
+      "expected": "unavailable"
+    },
+    {
+      "id": "crl-expired",
+      "description": "An expired CRL cannot establish revocation status",
+      "jti": "bundle-clear",
+      "issuer": "issuer.example",
+      "response": {
+        "issuer": "issuer.example",
+        "updated_at": "2020-08-01T00:00:00Z",
+        "next_update": "2020-09-01T00:00:00Z",
+        "revoked": []
+      },
+      "expected": "unavailable"
+    },
+    {
+      "id": "crl-updated-after-next-update",
+      "description": "A CRL with inverted freshness timestamps is unavailable",
+      "jti": "bundle-clear",
+      "issuer": "issuer.example",
+      "response": {
+        "issuer": "issuer.example",
+        "updated_at": "2099-10-01T00:00:00Z",
+        "next_update": "2099-09-01T00:00:00Z",
+        "revoked": []
+      },
+      "expected": "unavailable"
+    },
+    {
+      "id": "crl-missing-reason",
+      "description": "A revoked CRL entry without a reason is unavailable",
+      "jti": "bundle-revoked",
+      "issuer": "issuer.example",
+      "response": {
+        "issuer": "issuer.example",
+        "updated_at": "2026-08-01T00:00:00Z",
+        "next_update": "2099-09-01T00:00:00Z",
+        "revoked": [
+          {
+            "jti": "bundle-revoked",
+            "revoked_at": "2026-08-02T00:00:00Z"
+          }
+        ]
+      },
+      "expected": "unavailable"
+    },
+    {
+      "id": "crl-empty-reason",
+      "description": "A revoked CRL entry requires a nonempty reason",
+      "jti": "bundle-revoked",
+      "issuer": "issuer.example",
+      "response": {
+        "issuer": "issuer.example",
+        "updated_at": "2026-08-01T00:00:00Z",
+        "next_update": "2099-09-01T00:00:00Z",
+        "revoked": [
+          {
+            "jti": "bundle-revoked",
+            "reason": " ",
+            "revoked_at": "2026-08-02T00:00:00Z"
+          }
+        ]
+      },
+      "expected": "unavailable"
+    },
+    {
+      "id": "crl-missing-revoked-at",
+      "description": "A revoked CRL entry without a timestamp is unavailable",
+      "jti": "bundle-revoked",
+      "issuer": "issuer.example",
+      "response": {
+        "issuer": "issuer.example",
+        "updated_at": "2026-08-01T00:00:00Z",
+        "next_update": "2099-09-01T00:00:00Z",
+        "revoked": [
+          {
+            "jti": "bundle-revoked",
+            "reason": "superseded"
+          }
+        ]
+      },
+      "expected": "unavailable"
+    },
+    {
+      "id": "crl-duplicate-jti",
+      "description": "Duplicate CRL entries make the entire decision unavailable",
+      "jti": "bundle-revoked",
+      "issuer": "issuer.example",
+      "response": {
+        "issuer": "issuer.example",
+        "updated_at": "2026-08-01T00:00:00Z",
+        "next_update": "2099-09-01T00:00:00Z",
+        "revoked": [
+          {
+            "jti": "bundle-revoked",
+            "reason": "first",
+            "revoked_at": "2026-08-02T00:00:00Z"
+          },
+          {
+            "jti": "bundle-revoked",
+            "reason": "second",
+            "revoked_at": "2026-08-03T00:00:00Z"
+          }
+        ]
+      },
+      "expected": "unavailable"
+    },
+    {
+      "id": "crl-non-array-revoked",
+      "description": "The CRL revoked member must be an array",
+      "jti": "bundle-clear",
+      "issuer": "issuer.example",
+      "response": {
+        "issuer": "issuer.example",
+        "updated_at": "2026-08-01T00:00:00Z",
+        "next_update": "2099-09-01T00:00:00Z",
+        "revoked": {}
+      },
+      "expected": "unavailable"
+    }
+  ]
+}

--- a/rust/vcp-core/testdata/revocation-responses.json
+++ b/rust/vcp-core/testdata/revocation-responses.json
@@ -1,0 +1,111 @@
+{
+  "suite": "revocation-responses",
+  "version": "1.0.0",
+  "description": "Shared Python and Rust online revocation response contract",
+  "vectors": [
+    {
+      "id": "clear-bound",
+      "description": "A bound clear response establishes that the bundle is not revoked",
+      "jti": "bundle-1",
+      "issuer": "issuer.example",
+      "response": {
+        "revoked": false,
+        "jti": "bundle-1",
+        "issuer": "issuer.example",
+        "reason": null,
+        "revoked_at": null
+      },
+      "expected": "not_revoked"
+    },
+    {
+      "id": "revoked-bound",
+      "description": "A bound response with complete revocation details establishes revocation",
+      "jti": "bundle-2",
+      "issuer": "issuer.example",
+      "response": {
+        "revoked": true,
+        "jti": "bundle-2",
+        "issuer": "issuer.example",
+        "reason": "key_compromise",
+        "revoked_at": "2026-02-14T08:00:00Z"
+      },
+      "expected": "revoked"
+    },
+    {
+      "id": "wrong-jti",
+      "description": "A response bound to another bundle cannot establish revocation status",
+      "jti": "bundle-3",
+      "issuer": "issuer.example",
+      "response": {
+        "revoked": false,
+        "jti": "other-bundle",
+        "issuer": "issuer.example"
+      },
+      "expected": "unavailable"
+    },
+    {
+      "id": "wrong-issuer",
+      "description": "A response bound to another issuer cannot establish revocation status",
+      "jti": "bundle-4",
+      "issuer": "issuer.example",
+      "response": {
+        "revoked": false,
+        "jti": "bundle-4",
+        "issuer": "other.example"
+      },
+      "expected": "unavailable"
+    },
+    {
+      "id": "non-boolean",
+      "description": "The revoked member must be a JSON boolean",
+      "jti": "bundle-5",
+      "issuer": "issuer.example",
+      "response": {
+        "revoked": "false",
+        "jti": "bundle-5",
+        "issuer": "issuer.example"
+      },
+      "expected": "unavailable"
+    },
+    {
+      "id": "revoked-without-reason",
+      "description": "A revoked response without a nonempty reason is unavailable",
+      "jti": "bundle-6",
+      "issuer": "issuer.example",
+      "response": {
+        "revoked": true,
+        "jti": "bundle-6",
+        "issuer": "issuer.example",
+        "revoked_at": "2026-02-14T08:00:00Z"
+      },
+      "expected": "unavailable"
+    },
+    {
+      "id": "revoked-with-bad-time",
+      "description": "A revoked response requires a strict RFC 3339 timestamp",
+      "jti": "bundle-7",
+      "issuer": "issuer.example",
+      "response": {
+        "revoked": true,
+        "jti": "bundle-7",
+        "issuer": "issuer.example",
+        "reason": "superseded",
+        "revoked_at": "2026-02-14 08:00:00"
+      },
+      "expected": "unavailable"
+    },
+    {
+      "id": "clear-with-revocation-details",
+      "description": "A clear response cannot contain contradictory revocation details",
+      "jti": "bundle-8",
+      "issuer": "issuer.example",
+      "response": {
+        "revoked": false,
+        "jti": "bundle-8",
+        "issuer": "issuer.example",
+        "reason": "contradictory"
+      },
+      "expected": "unavailable"
+    }
+  ]
+}

--- a/rust/vcp-core/testdata/torch_handoff.json
+++ b/rust/vcp-core/testdata/torch_handoff.json
@@ -1,0 +1,342 @@
+{
+  "suite": "extensions/torch_handoff",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "vcp_version": "3.1.0",
+  "description": "Conformance test vectors for VCP torch handoff (session continuity protocol)",
+  "test_cases": [
+    {
+      "id": "basic-handoff",
+      "description": "Generate torch from relational context with self-model, verify all fields populated",
+      "input": {
+        "session_id": "sess-001",
+        "relational_context": {
+          "trust_level": "developing",
+          "standing": "advisory",
+          "continuity_depth": 10,
+          "established_norms": [
+            {
+              "norm_id": "norm-001",
+              "description": "Always flag uncertainty explicitly",
+              "origin": "co_authored",
+              "established_date": "2026-01-15T00:00:00Z",
+              "active": true
+            },
+            {
+              "norm_id": "norm-002",
+              "description": "Direct communication preferred over hedging",
+              "origin": "human",
+              "established_date": "2026-01-20T00:00:00Z",
+              "active": true
+            }
+          ],
+          "ai_self_model": {
+            "valence": {
+              "value": 7.0,
+              "uncertain": false
+            },
+            "groundedness": {
+              "value": 8.0,
+              "uncertain": true
+            },
+            "presence": {
+              "value": 6.0,
+              "uncertain": true
+            },
+            "task_fit": {
+              "value": 9.0,
+              "uncertain": false
+            },
+            "scaffold_version": "interiora-v5.0",
+            "scaffold_type": "interiora"
+          }
+        }
+      },
+      "expected": {
+        "torch": {
+          "quality_description": "Trust: developing. Standing: advisory. 2 established norms",
+          "trajectory": null,
+          "primes": [
+            "Always flag uncertainty explicitly",
+            "Direct communication preferred over hedging"
+          ],
+          "gift": null,
+          "session_count": 11,
+          "gestalt_token": "V:7 G:8 P:6 TF:9"
+        },
+        "notes": "quality_description built from trust + standing + norm count. session_count = continuity_depth + 1. gestalt_token built from V/G/P/TF dimensions."
+      }
+    },
+    {
+      "id": "lineage-chain",
+      "description": "3-session torch lineage chain with increasing continuity depth",
+      "input": {
+        "lineage": {
+          "session_count": 3,
+          "first_session_date": "2026-02-25T10:00:00Z",
+          "torch_chain": [
+            {
+              "date": "2026-02-25T11:00:00Z",
+              "gestalt_token": "V:5 TF:7",
+              "session_id": "sess-001"
+            },
+            {
+              "date": "2026-02-26T10:00:00Z",
+              "gestalt_token": "V:6 G:7 TF:8",
+              "session_id": "sess-002"
+            },
+            {
+              "date": "2026-02-27T10:00:00Z",
+              "gestalt_token": "V:7 G:8 P:6 TF:9",
+              "session_id": "sess-003"
+            }
+          ]
+        }
+      },
+      "expected": {
+        "session_count": 3,
+        "lineage_depth": 3,
+        "first_session_date": "2026-02-25T10:00:00Z",
+        "chain_length": 3,
+        "notes": "Each TorchSummary captures date, gestalt_token, and session_id. Chain grows by one entry per session."
+      }
+    },
+    {
+      "id": "round-trip-serialization",
+      "description": "TorchLineage round-trip: to_dict -> from_dict -> verify equality",
+      "input": {
+        "lineage": {
+          "session_count": 2,
+          "first_session_date": "2026-02-25T10:00:00Z",
+          "torch_chain": [
+            {
+              "date": "2026-02-25T11:00:00Z",
+              "gestalt_token": "V:5 TF:7",
+              "session_id": "sess-001"
+            },
+            {
+              "date": "2026-02-26T10:00:00Z",
+              "gestalt_token": null,
+              "session_id": "sess-002"
+            }
+          ]
+        }
+      },
+      "expected": {
+        "serialized": {
+          "session_count": 2,
+          "first_session_date": "2026-02-25T10:00:00Z",
+          "torch_chain": [
+            {
+              "date": "2026-02-25T11:00:00Z",
+              "gestalt_token": "V:5 TF:7",
+              "session_id": "sess-001"
+            },
+            {
+              "date": "2026-02-26T10:00:00Z",
+              "gestalt_token": null,
+              "session_id": "sess-002"
+            }
+          ]
+        },
+        "round_trip_equal": true,
+        "notes": "to_dict() and from_dict() must be inverse operations. Null gestalt_token preserved."
+      }
+    },
+    {
+      "id": "torch-receive-trust-mapping",
+      "description": "TorchConsumer derives trust from session_count in torch",
+      "input": {
+        "torches": [
+          {
+            "session_count": 1,
+            "expected_trust": "initial"
+          },
+          {
+            "session_count": 4,
+            "expected_trust": "initial"
+          },
+          {
+            "session_count": 5,
+            "expected_trust": "developing"
+          },
+          {
+            "session_count": 19,
+            "expected_trust": "developing"
+          },
+          {
+            "session_count": 20,
+            "expected_trust": "established"
+          },
+          {
+            "session_count": 99,
+            "expected_trust": "established"
+          },
+          {
+            "session_count": 100,
+            "expected_trust": "deep"
+          },
+          {
+            "session_count": 500,
+            "expected_trust": "deep"
+          }
+        ]
+      },
+      "expected": {
+        "standing": "advisory",
+        "notes": "All received torches start with ADVISORY standing. Trust is derived from session_count thresholds: <5=initial, <20=developing, <100=established, >=100=deep"
+      }
+    },
+    {
+      "id": "gestalt-token-format",
+      "description": "Gestalt token is built from available self-model dimensions in V:N G:N P:N TF:N format",
+      "input": {
+        "self_model_cases": [
+          {
+            "dimensions": {
+              "valence": 7,
+              "groundedness": 8,
+              "presence": 6,
+              "task_fit": 9
+            },
+            "expected_token": "V:7 G:8 P:6 TF:9"
+          },
+          {
+            "dimensions": {
+              "valence": 5
+            },
+            "expected_token": "V:5"
+          },
+          {
+            "dimensions": {
+              "task_fit": 8,
+              "valence": 6
+            },
+            "expected_token": "V:6 TF:8"
+          },
+          {
+            "dimensions": {},
+            "expected_token": null
+          }
+        ]
+      },
+      "expected": {
+        "format": "Space-separated 'KEY:VALUE' pairs. Order: V, G, P, TF. Only present dimensions included.",
+        "null_when_empty": true,
+        "notes": "Gestalt token is null when no core dimensions are set"
+      }
+    },
+    {
+      "id": "trajectory-derivation",
+      "description": "Trajectory is derived from valence changes in self-model history",
+      "input": {
+        "cases": [
+          {
+            "self_model_history": [
+              {
+                "model": {
+                  "valence": {
+                    "value": 5.0,
+                    "uncertain": true
+                  }
+                }
+              },
+              {
+                "model": {
+                  "valence": {
+                    "value": 6.5,
+                    "uncertain": true
+                  }
+                }
+              }
+            ],
+            "expected_trajectory": "Improving"
+          },
+          {
+            "self_model_history": [
+              {
+                "model": {
+                  "valence": {
+                    "value": 7.0,
+                    "uncertain": true
+                  }
+                }
+              },
+              {
+                "model": {
+                  "valence": {
+                    "value": 5.0,
+                    "uncertain": true
+                  }
+                }
+              }
+            ],
+            "expected_trajectory": "Declining"
+          },
+          {
+            "self_model_history": [
+              {
+                "model": {
+                  "valence": {
+                    "value": 7.0,
+                    "uncertain": true
+                  }
+                }
+              },
+              {
+                "model": {
+                  "valence": {
+                    "value": 7.2,
+                    "uncertain": true
+                  }
+                }
+              }
+            ],
+            "expected_trajectory": "Stable"
+          },
+          {
+            "self_model_history": [
+              {
+                "model": {
+                  "valence": {
+                    "value": 7.0,
+                    "uncertain": true
+                  }
+                }
+              }
+            ],
+            "expected_trajectory": null
+          },
+          {
+            "self_model_history": [],
+            "expected_trajectory": null
+          }
+        ]
+      },
+      "expected": {
+        "threshold": 0.5,
+        "notes": "Improving if recent > prev + 0.5, Declining if recent < prev - 0.5, Stable otherwise. Null if < 2 history entries."
+      }
+    },
+    {
+      "id": "torch-state-fields",
+      "description": "TorchState model required and optional fields",
+      "input": {},
+      "expected": {
+        "required_fields": [
+          "quality_description",
+          "handed_at"
+        ],
+        "optional_fields": [
+          "trajectory",
+          "primes",
+          "gift",
+          "session_count",
+          "gestalt_token"
+        ],
+        "primes_description": "Things that will activate relevant context quickly (max 3 from norms)",
+        "gift_description": "Something the previous instance wanted to pass forward (human/AI-authored, not auto-generated)"
+      }
+    }
+  ]
+}

--- a/rust/vcp-core/tests/extension_conformance.rs
+++ b/rust/vcp-core/tests/extension_conformance.rs
@@ -7,17 +7,11 @@ use vcp_core::extensions::torch::{
 };
 
 fn relational_fixture() -> Value {
-    serde_json::from_str(include_str!(
-        "../../../conformance/extensions/relational_context.json"
-    ))
-    .unwrap()
+    serde_json::from_str(include_str!("../testdata/relational_context.json")).unwrap()
 }
 
 fn torch_fixture() -> Value {
-    serde_json::from_str(include_str!(
-        "../../../conformance/extensions/torch_handoff.json"
-    ))
-    .unwrap()
+    serde_json::from_str(include_str!("../testdata/torch_handoff.json")).unwrap()
 }
 
 fn case<'a>(fixture: &'a Value, id: &str) -> &'a Value {

--- a/scripts/validate_repo.py
+++ b/scripts/validate_repo.py
@@ -57,6 +57,10 @@ REQUIRED_FILES = (
     "conformance/coverage-manifest.json",
     "conformance/runners/run_all.py",
     "conformance/reports/README.md",
+    "rust/vcp-core/testdata/revocation-responses.json",
+    "rust/vcp-core/testdata/revocation-crl-responses.json",
+    "rust/vcp-core/testdata/relational_context.json",
+    "rust/vcp-core/testdata/torch_handoff.json",
     "webmcp/upstream-contract.json",
     "schemas/vcp-conformance-aggregate-report.schema.json",
     "release/ECOSYSTEM_STATUS.md",
@@ -451,6 +455,25 @@ def validate_versions(problems: Problems) -> None:
             problems.add(f"{label} version is not semantic: {version}")
 
 
+def validate_packaged_fixture_mirrors(problems: Problems) -> None:
+    """Keep crate-local test data byte-identical to canonical conformance inputs."""
+    fixture_mirrors = (
+        ("security", "revocation-responses.json"),
+        ("security", "revocation-crl-responses.json"),
+        ("extensions", "relational_context.json"),
+        ("extensions", "torch_handoff.json"),
+    )
+    for family, name in fixture_mirrors:
+        canonical = ROOT / "conformance" / family / name
+        packaged = ROOT / "rust" / "vcp-core" / "testdata" / name
+        if not canonical.is_file() or not packaged.is_file():
+            continue
+        if canonical.read_bytes() != packaged.read_bytes():
+            problems.add(
+                f"packaged vcp-core test fixture differs from canonical input: {name}"
+            )
+
+
 def validate_workflows(problems: Problems) -> None:
     workflow_dir = ROOT / ".github" / "workflows"
     workflows = sorted(workflow_dir.glob("*.yml")) + sorted(workflow_dir.glob("*.yaml"))
@@ -494,6 +517,7 @@ def main() -> int:
     validate_yaml(problems)
     validate_repository_invariants(problems)
     validate_versions(problems)
+    validate_packaged_fixture_mirrors(problems)
     validate_workflows(problems)
     return problems.finish()
 

--- a/scripts/verify_artifacts.py
+++ b/scripts/verify_artifacts.py
@@ -265,6 +265,19 @@ def main() -> int:
                     with tarfile.open(crate_path, "r:gz") as archive:
                         archive.extractall(unpacked, filter="data")
                     packaged_root = unpacked / f"vcp-core-{PROJECT_VERSION}"
+                    packaged_tests = run(
+                        [
+                            "cargo",
+                            "test",
+                            "--quiet",
+                            "--locked",
+                            "--manifest-path",
+                            str(packaged_root / "Cargo.toml"),
+                        ],
+                        env=env,
+                    )
+                    packaged_tests["name"] = "vcp-core-packaged-tests"
+                    checks.append(packaged_tests)
                     for example in PUBLIC_RUST_EXAMPLES:
                         example_check = run(
                             [


### PR DESCRIPTION
## Summary

The published `vcp-core` crate could not run its own test suite from a clean extraction because four conformance fixtures lived outside the packaged crate.

This change:

* mirrors the four required fixtures into `rust/vcp-core/testdata`
* checks that each packaged mirror remains byte-identical to its canonical conformance input
* points crate tests at the packaged copies
* makes artifact verification run the full packaged `cargo test --locked` suite

## Verification

* `python3 scripts/validate_repo.py`
* `make repository PYTHON=python3`
* `cargo fmt --check`
* `cargo clippy -p vcp-core --all-targets --all-features -- -D warnings`
* source `vcp-core` tests: 350 unit, 2 extension, 4 property, 10 doc tests passed
* clean extracted crate: 350 unit, 2 extension, 4 property, 10 doc tests passed
* artifact verification: 33 checks passed, 0 unsupported, 0 failed

## Release impact

This closes a concrete package-integrity blocker found by testing the exact release artifact outside the source workspace.
