### PR TITLE
Fix publication ledger phase sequencing

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,4 @@
+# Historical, project-namespaced illustrative registry verification values.
+# These exact findings are duplicated documentation examples, not credentials.
+bf89cba5d0f993e07177fc0f26a338596c70a0e2:docs/identity/VCP_IDENTITY_NAMESPACE.md:generic-api-key:252
+bf89cba5d0f993e07177fc0f26a338596c70a0e2:docs/uvc/UVC_NAMESPACE_GOVERNANCE.md:generic-api-key:250

--- a/python/tests/tooling/test_validate_review_ledger.py
+++ b/python/tests/tooling/test_validate_review_ledger.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "validate_review_ledger.py"
+SPEC = importlib.util.spec_from_file_location("validate_review_ledger", SCRIPT)
+assert SPEC and SPEC.loader
+ledger_validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ledger_validator)
+
+
+def prepublication_ledger() -> dict[str, object]:
+    ledger = json.loads((ROOT / "release/review-ledger.template.json").read_text())
+    candidate = ledger["candidate"]
+    for index, repository in enumerate(candidate["repositories"], start=1):
+        repository["commit"] = f"{index}" * 40
+        repository["working_tree_sha256"] = f"{index}" * 64
+    candidate["combined_candidate_sha256"] = "a" * 64
+    candidate["source_manifest_sha256"] = "b" * 64
+    candidate["protocol"]["amendment_maturity"] = "candidate"
+    candidate["deployment"]["environment"] = "production"
+    candidate["deployment"]["url"] = "https://valuecontextprotocol.org/"
+
+    for review in ledger["reviews"]:
+        gate_id = review["id"]
+        if gate_id in ledger_validator.POST_PUBLICATION_GATES:
+            continue
+        review["status"] = "approved"
+        review["reviewer"] = {
+            "name": f"Reviewer {gate_id}",
+            "role": "authorized reviewer",
+            "organization": "Example review body",
+            "independence_statement": (
+                "No implementation authorship or conflicting financial interest."
+            ),
+        }
+        review["reviewed_at"] = "2026-08-15T00:00:00Z"
+        review["decision_summary"] = (
+            f"Gate {gate_id} approved for the exact candidate and evidence set."
+        )
+        review["evidence"] = [
+            {
+                "kind": kind,
+                "uri": f"evidence/{gate_id}/{kind}.json",
+                "sha256": "c" * 64,
+            }
+            for kind in sorted(ledger_validator.REQUIRED_EVIDENCE[gate_id])
+        ]
+        review["attestation"] = {
+            "method": "signed-review-record",
+            "identity": f"reviewer:{gate_id}",
+            "signed_at": "2026-08-15T00:00:00Z",
+            "value": f"approval-{gate_id}",
+        }
+    return ledger
+
+
+def semantic_problems(
+    ledger: dict[str, object], *, prepublication: bool, complete: bool
+) -> list[str]:
+    problems = ledger_validator.Problems()
+    ledger_validator.validate_review_shape(ledger, problems)
+    ledger_validator.validate_candidate_semantics(
+        ledger,
+        problems,
+        prepublication,
+        complete,
+    )
+    return problems.items
+
+
+def test_prepublication_allows_only_postpublication_gates_to_remain_pending() -> None:
+    assert not semantic_problems(prepublication_ledger(), prepublication=True, complete=False)
+
+
+def test_complete_requires_postpublication_gates_and_deployment_receipt() -> None:
+    problems = semantic_problems(prepublication_ledger(), prepublication=False, complete=True)
+    assert any("X018=pending" in problem for problem in problems)
+    assert any("K044=pending" in problem for problem in problems)
+    assert "require-complete needs deployment.release_id" in problems
+    assert "require-complete needs deployment.deployed_at" in problems
+
+
+def test_prepublication_rejects_nonfinal_required_decision() -> None:
+    ledger = copy.deepcopy(prepublication_ledger())
+    review = next(item for item in ledger["reviews"] if item["id"] == "X015")
+    review["status"] = "rejected"
+    problems = semantic_problems(ledger, prepublication=True, complete=False)
+    assert any("X015=rejected" in problem for problem in problems)
+
+
+def test_prepublication_rejects_unresolved_conditional_approval() -> None:
+    ledger = copy.deepcopy(prepublication_ledger())
+    review = next(item for item in ledger["reviews"] if item["id"] == "X015")
+    review["status"] = "approved_with_conditions"
+    review["conditions"] = ["Publish only after the named condition closes."]
+    problems = semantic_problems(ledger, prepublication=True, complete=False)
+    assert any("X015=approved_with_conditions" in problem for problem in problems)

--- a/release/COORDINATED_RELEASE_RUNBOOK.md
+++ b/release/COORDINATED_RELEASE_RUNBOOK.md
@@ -166,7 +166,17 @@ python scripts/validate_review_ledger.py \
   /secure/path/vcp-release-evidence/review-ledger.json
 ```
 
-The archival ledger must also pass:
+Before registry publication, require every decision through X015 while leaving
+K044 and X018 available for the receipts and smoke evidence that publication
+itself creates:
+
+```bash
+python scripts/validate_review_ledger.py \
+  /secure/path/vcp-release-evidence/review-ledger.json \
+  --require-prepublication
+```
+
+The final archival ledger must also pass:
 
 ```bash
 python scripts/validate_review_ledger.py \
@@ -174,9 +184,11 @@ python scripts/validate_review_ledger.py \
   --require-complete
 ```
 
-`--require-complete` checks that all 13 decisions exist. It does not reinterpret
-a rejection as approval. The release coordinator must stop when any required
-gate is rejected or has unresolved conditions.
+`--require-prepublication` requires a final disposition for every gate except
+K044 and X018. `--require-complete` requires a final disposition for all 13
+decisions, the deployment identity, and the post-publication evidence. Neither
+mode reinterprets a rejection or unresolved conditional approval as
+authorization.
 
 ## 6. Gate order and dependencies
 
@@ -230,9 +242,11 @@ sequence in two modes. `dry-run` builds twice from clean checkouts, compares
 every delivered byte, generates CycloneDX SBOMs and a final SHA-256 manifest,
 and requests GitHub artifact attestations. `publish` additionally requires an
 exact signed `v<version>` tag, the protected `vcp-release-approval`
-environment, a complete coordinated review ledger, ratified package names, and
-registry-specific protected environments. The current source-only publication
-state deliberately causes that publication preflight to fail.
+environment, a coordinated ledger that passes `--require-prepublication`,
+ratified package names, and registry-specific protected environments. K044 and
+X018 are then completed from the publication receipts and production smoke
+evidence before the ledger passes `--require-complete`. The current source-only
+publication state deliberately causes publication preflight to fail.
 
 1. Create signed, immutable repository tags for the approved Spec and SDK
    commits. Record tag-object hashes and signature verification output.

--- a/scripts/check_release_authority.py
+++ b/scripts/check_release_authority.py
@@ -60,13 +60,16 @@ def main() -> int:
                     sys.executable,
                     str(ROOT / "scripts" / "validate_review_ledger.py"),
                     str(ledger),
-                    "--require-complete",
+                    "--require-prepublication",
                 ],
                 cwd=ROOT,
                 check=False,
             )
             if validation.returncode:
-                problems.append("the coordinated human review ledger is not complete")
+                problems.append(
+                    "the coordinated review ledger has not passed "
+                    "prepublication validation"
+                )
 
     if problems:
         for problem in problems:

--- a/scripts/validate_review_ledger.py
+++ b/scripts/validate_review_ledger.py
@@ -53,6 +53,8 @@ REQUIRED_EVIDENCE: dict[str, set[str]] = {
 }
 
 INDEPENDENT_GATES = {"X017", "S033", "K045"}
+POST_PUBLICATION_GATES = {"K044", "X018"}
+FINAL_STATUSES = {"approved", "not_applicable"}
 
 
 class Problems:
@@ -173,7 +175,10 @@ def validate_review_shape(ledger: dict[str, Any], problems: Problems) -> None:
 
 
 def validate_candidate_semantics(
-    ledger: dict[str, Any], problems: Problems, require_complete: bool
+    ledger: dict[str, Any],
+    problems: Problems,
+    require_prepublication: bool,
+    require_complete: bool,
 ) -> None:
     candidate = ledger.get("candidate", {})
     reviews = ledger.get("reviews", [])
@@ -181,40 +186,62 @@ def validate_candidate_semantics(
         isinstance(review, dict) and review.get("status") != "pending"
         for review in reviews
     )
-    if has_completed_review or require_complete:
+    if has_completed_review or require_prepublication or require_complete:
         candidate_is_locked(candidate, problems)
 
-    if require_complete:
-        pending = [
-            review.get("id")
+    if require_prepublication or require_complete:
+        required_gates = set(EXPECTED_REVIEWS)
+        phase = "require-complete"
+        if require_prepublication:
+            required_gates -= POST_PUBLICATION_GATES
+            phase = "require-prepublication"
+        blocking = [
+            f"{review.get('id')}={review.get('status')}"
             for review in reviews
-            if isinstance(review, dict) and review.get("status") == "pending"
+            if isinstance(review, dict)
+            and review.get("id") in required_gates
+            and review.get("status") not in FINAL_STATUSES
         ]
-        if pending:
-            problems.add(f"require-complete found pending gates: {', '.join(pending)}")
+        if blocking:
+            problems.add(f"{phase} found non-final gates: {', '.join(blocking)}")
 
         protocol = candidate.get("protocol", {})
         if not protocol.get("amendment_maturity"):
-            problems.add("completed ledger needs the v3.2 amendment maturity decision")
+            problems.add(f"{phase} needs the v3.2 amendment maturity decision")
         versions = candidate.get("versions", {})
         for name in ("python", "rust", "webmcp", "demo"):
             version = versions.get(name)
             if not isinstance(version, str) or not SEMVER_RE.fullmatch(version):
-                problems.add(f"completed ledger needs a semantic {name} version")
+                problems.add(f"{phase} needs a semantic {name} version")
         deployment = candidate.get("deployment", {})
-        for name in ("environment", "url", "release_id", "deployed_at"):
+        deployment_fields = ["environment", "url"]
+        if require_complete:
+            deployment_fields.extend(["release_id", "deployed_at"])
+        for name in deployment_fields:
             if not deployment.get(name):
-                problems.add(f"completed ledger needs deployment.{name}")
+                problems.add(f"{phase} needs deployment.{name}")
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("ledger", nargs="?", type=Path, default=DEFAULT_LEDGER)
     parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
-    parser.add_argument(
+    phase = parser.add_mutually_exclusive_group()
+    phase.add_argument(
+        "--require-prepublication",
+        action="store_true",
+        help=(
+            "require exact candidate identity and every decision that must exist "
+            "before registry publication"
+        ),
+    )
+    phase.add_argument(
         "--require-complete",
         action="store_true",
-        help="require exact candidate identity, deployment identity, and no pending gates",
+        help=(
+            "require exact candidate and deployment identity plus every final "
+            "post-publication decision"
+        ),
     )
     return parser.parse_args()
 
@@ -239,7 +266,12 @@ def main() -> int:
 
     if isinstance(ledger, dict):
         validate_review_shape(ledger, problems)
-        validate_candidate_semantics(ledger, problems, args.require_complete)
+        validate_candidate_semantics(
+            ledger,
+            problems,
+            args.require_prepublication,
+            args.require_complete,
+        )
     else:
         problems.add("ledger root must be an object")
     return problems.finish()


### PR DESCRIPTION
## Summary

* split coordinated ledger enforcement into explicit prepublication and final archival phases
* require all prepublication decisions to be approved or not applicable, while rejecting pending, rejected, or conditionally approved gates
* reserve K044 registry receipts and X018 production smoke evidence for the postpublication phase that can actually produce them
* add focused validator tests and exact historical false-positive suppressions for the configured secret-history scan
* document the corrected release sequence

## Why

The publication workflow previously required a fully complete ledger before registry upload. That was impossible because K044 requires registry receipts and X018 requires postpublication production smoke evidence. The workflow now fails closed on every decision that can be completed before publication, then requires the final ledger after publication evidence exists.

## Verification

* four focused ledger-validator tests pass
* repository structural validation passes
* Ruff check and format check pass
* configured current-tree and full-history Gitleaks scans pass
* staged tree and reachable history contain no files over 50 MiB
