### PR TITLE
Bind publication to a protected external review ledger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ on:
         required: true
         type: string
         default: 4.2.0
+      review_ledger_sha256:
+        description: Exact protected review-ledger SHA-256, required for publish mode
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -179,12 +184,52 @@ jobs:
           python -m pip install 'pip==26.2.1'
           python -m pip install --require-hashes --requirement python/requirements-dev.lock
 
+      - name: Materialize the hash-bound protected review ledger
+        env:
+          VCP_REVIEW_LEDGER_B64: ${{ secrets.VCP_REVIEW_LEDGER_B64 }}
+          VCP_REVIEW_LEDGER_SHA256: ${{ inputs.review_ledger_sha256 }}
+        run: |
+          python - <<'PY'
+          import base64
+          import binascii
+          import hashlib
+          import hmac
+          import os
+          import re
+          from pathlib import Path
+
+          encoded = os.environ.get("VCP_REVIEW_LEDGER_B64", "")
+          expected = os.environ.get("VCP_REVIEW_LEDGER_SHA256", "")
+          if not encoded:
+              raise SystemExit("VCP_REVIEW_LEDGER_B64 is not configured")
+          if not re.fullmatch(r"[0-9a-f]{64}", expected):
+              raise SystemExit("publish mode needs an exact review_ledger_sha256")
+          try:
+              payload = base64.b64decode(encoded, validate=True)
+          except (ValueError, binascii.Error) as exc:
+              raise SystemExit("VCP_REVIEW_LEDGER_B64 is not valid base64") from exc
+          actual = hashlib.sha256(payload).hexdigest()
+          if not hmac.compare_digest(actual, expected):
+              raise SystemExit("protected review ledger SHA-256 does not match dispatch")
+
+          ledger = Path(os.environ["RUNNER_TEMP"]) / "review-ledger.json"
+          ledger.write_bytes(payload)
+          ledger.chmod(0o600)
+          with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as stream:
+              stream.write(f"VCP_REVIEW_LEDGER={ledger}\n")
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open(
+              "a", encoding="utf-8"
+          ) as stream:
+              stream.write(f"Protected review ledger SHA-256: `{actual}`\n")
+          PY
+
       - name: Require signed-off candidate state and exact immutable tag
         run: |
           test "$GITHUB_REF" = "refs/tags/v${{ inputs.version }}"
           git verify-tag "v${{ inputs.version }}"
           python scripts/check_release_authority.py \
             --version "${{ inputs.version }}" \
+            --ledger "$VCP_REVIEW_LEDGER" \
             --publish
 
   publish-pypi:

--- a/python/tests/tooling/test_check_release_authority.py
+++ b/python/tests/tooling/test_check_release_authority.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "check_release_authority.py"
+TEMPLATE = ROOT / "release" / "review-ledger.template.json"
+
+
+def run_publish(*, ledger: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--version",
+            "4.2.0",
+            "--publish",
+            "--ledger",
+            str(ledger),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_publish_uses_external_ledger_path(tmp_path: Path) -> None:
+    ledger = tmp_path / "review-ledger.json"
+    ledger.write_bytes(TEMPLATE.read_bytes())
+    result = run_publish(ledger=ledger)
+    assert result.returncode == 1
+    assert "review ledger is missing" not in result.stderr
+    assert "has not passed prepublication validation" in result.stderr
+
+
+def test_publish_fails_closed_when_external_ledger_is_missing(
+    tmp_path: Path,
+) -> None:
+    result = run_publish(ledger=tmp_path / "missing.json")
+    assert result.returncode == 1
+    assert "review ledger is missing" in result.stderr

--- a/python/tests/tooling/test_release_workflow.py
+++ b/python/tests/tooling/test_release_workflow.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github/workflows/release.yml"
+
+
+def materialization_script() -> str:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    steps = workflow["jobs"]["authorize-publication"]["steps"]
+    step = next(
+        item
+        for item in steps
+        if item.get("name") == "Materialize the hash-bound protected review ledger"
+    )
+    return step["run"]
+
+
+def run_materialization(
+    tmp_path: Path, *, payload: bytes, expected_sha256: str
+) -> subprocess.CompletedProcess[str]:
+    runner_temp = tmp_path / "runner"
+    runner_temp.mkdir()
+    environment = {
+        **os.environ,
+        "RUNNER_TEMP": str(runner_temp),
+        "GITHUB_ENV": str(tmp_path / "github-env"),
+        "GITHUB_STEP_SUMMARY": str(tmp_path / "summary"),
+        "VCP_REVIEW_LEDGER_B64": base64.b64encode(payload).decode(),
+        "VCP_REVIEW_LEDGER_SHA256": expected_sha256,
+        "PATH": f"{Path(sys.executable).parent}:{os.environ['PATH']}",
+    }
+    return subprocess.run(
+        ["bash", "-eo", "pipefail", "-c", materialization_script()],
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_protected_ledger_is_hash_bound_and_written_privately(tmp_path: Path) -> None:
+    payload = (ROOT / "release/review-ledger.template.json").read_bytes()
+    digest = hashlib.sha256(payload).hexdigest()
+    result = run_materialization(tmp_path, payload=payload, expected_sha256=digest)
+    assert result.returncode == 0, result.stderr
+
+    ledger = tmp_path / "runner/review-ledger.json"
+    assert ledger.read_bytes() == payload
+    assert stat.S_IMODE(ledger.stat().st_mode) == 0o600
+    assert (tmp_path / "github-env").read_text() == f"VCP_REVIEW_LEDGER={ledger}\n"
+    assert digest in (tmp_path / "summary").read_text()
+
+
+def test_protected_ledger_rejects_digest_mismatch(tmp_path: Path) -> None:
+    result = run_materialization(
+        tmp_path,
+        payload=b'[{"untrusted": "ledger"}]',
+        expected_sha256="0" * 64,
+    )
+    assert result.returncode != 0
+    assert "does not match dispatch" in result.stderr
+    assert not (tmp_path / "runner/review-ledger.json").exists()

--- a/python/tests/tooling/test_release_workflow.py
+++ b/python/tests/tooling/test_release_workflow.py
@@ -8,10 +8,15 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW = ROOT / ".github/workflows/release.yml"
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="the protected publication job runs only on ubuntu-24.04 Bash",
+)
 
 
 def materialization_script() -> str:

--- a/release/COORDINATED_RELEASE_RUNBOOK.md
+++ b/release/COORDINATED_RELEASE_RUNBOOK.md
@@ -84,6 +84,10 @@ cp release/review-ledger.template.json \
 Never edit the repository template into an apparently approved state. The
 template is intentionally and permanently pending.
 
+Never commit the working ledger into a candidate repository. Besides exposing
+review material that may be access-controlled, doing so would change the SDK
+tree hash recorded inside the ledger and create a self-referential candidate.
+
 ## 4. Freeze and identify the candidate
 
 ### 4.1 Candidate prerequisites
@@ -190,6 +194,29 @@ decisions, the deployment identity, and the post-publication evidence. Neither
 mode reinterprets a rejection or unresolved conditional approval as
 authorization.
 
+After prepublication validation passes, bind the exact external ledger to the
+protected `vcp-release-approval` environment. The secret carries the private
+bytes; the workflow-dispatch input carries their public SHA-256:
+
+```bash
+python3 -c \
+  'import base64,sys; sys.stdout.write(base64.b64encode(sys.stdin.buffer.read()).decode())' \
+  < /secure/path/vcp-release-evidence/review-ledger.json \
+  | gh secret set VCP_REVIEW_LEDGER_B64 \
+      --repo Creed-Space/VCP-SDK \
+      --env vcp-release-approval
+
+shasum -a 256 \
+  /secure/path/vcp-release-evidence/review-ledger.json
+```
+
+Enter that digest as `review_ledger_sha256` when dispatching `publish`. The
+protected job decodes the secret into its temporary directory, checks the
+digest before parsing, validates the ledger against the tagged source, and
+prints only the digest to its step summary. Delete the environment secret after
+the publication workflow finishes and retain the final ledger in the controlled
+evidence archive.
+
 ## 6. Gate order and dependencies
 
 The recommended order minimizes review invalidation and prevents publication
@@ -243,10 +270,11 @@ every delivered byte, generates CycloneDX SBOMs and a final SHA-256 manifest,
 and requests GitHub artifact attestations. `publish` additionally requires an
 exact signed `v<version>` tag, the protected `vcp-release-approval`
 environment, a coordinated ledger that passes `--require-prepublication`,
-ratified package names, and registry-specific protected environments. K044 and
-X018 are then completed from the publication receipts and production smoke
-evidence before the ledger passes `--require-complete`. The current source-only
-publication state deliberately causes publication preflight to fail.
+an exact dispatch digest for the protected external ledger, ratified package
+names, and registry-specific protected environments. K044 and X018 are then
+completed from the publication receipts and production smoke evidence before
+the ledger passes `--require-complete`. The current source-only publication
+state deliberately causes publication preflight to fail.
 
 1. Create signed, immutable repository tags for the approved Spec and SDK
    commits. Record tag-object hashes and signature verification output.

--- a/scripts/check_release_authority.py
+++ b/scripts/check_release_authority.py
@@ -21,6 +21,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--version", required=True)
     parser.add_argument("--publish", action="store_true")
+    parser.add_argument(
+        "--ledger",
+        type=Path,
+        help="external coordinated review ledger used for publication authority",
+    )
     args = parser.parse_args()
     problems: list[str] = []
     python = tomllib.loads((ROOT / "python" / "pyproject.toml").read_text())["project"][
@@ -51,9 +56,11 @@ def main() -> int:
             problems.append(
                 "publication state must be candidate or published before registry upload"
             )
-        ledger = ROOT / "release" / "review-ledger.json"
-        if not ledger.is_file():
-            problems.append("release/review-ledger.json is missing")
+        ledger = args.ledger
+        if ledger is None:
+            problems.append("publication requires an external review ledger")
+        elif not ledger.is_file():
+            problems.append(f"review ledger is missing: {ledger}")
         else:
             validation = subprocess.run(
                 [


### PR DESCRIPTION
## Summary

* accept the coordinated review ledger from the protected release environment instead of the signed source tree
* bind the protected ledger bytes to a public SHA-256 supplied at workflow dispatch
* validate the external ledger against the exact tagged candidate before any registry job can start
* keep private review material outside public repositories and document safe secret intake and removal
* execute the exact embedded workflow materialization code in focused tests

## Why

A ledger committed inside the SDK candidate would change the tree hash recorded inside that same ledger. It would also contradict the controlled external evidence-directory policy. The protected environment-secret intake removes that self-reference while preserving fail-closed, candidate-bound authority.

## Verification

* eight focused release-authority, ledger-phase, and embedded-workflow tests pass
* actionlint passes the release workflow
* Ruff check and format check pass
* repository structural validation passes
* configured current-tree Gitleaks scan passes
* staged tree and reachable history contain no files over 50 MiB
