### PR TITLE
chore(webmcp): re-pin the upstream contract after reviewing three changes

### DIFF
--- a/webmcp/README.md
+++ b/webmcp/README.md
@@ -110,7 +110,7 @@ remote scripts and does not log loader errors by default.
 | Other browsers | No native claim; an application-owned bundled polyfill may be used behind explicit opt-in |
 | SSR | Safe; returns `{ api: 'unavailable', registered: [], failed: [] }` |
 
-Last reviewed: 2026-08-14. WebMCP remains under active development, so version
+Last reviewed: 2026-08-17. WebMCP remains under active development, so version
 numbers alone never establish browser support.
 
 ### Upstream contract monitoring

--- a/webmcp/upstream-contract.json
+++ b/webmcp/upstream-contract.json
@@ -1,16 +1,17 @@
 {
   "schema": "vcp-webmcp-upstream-contract/1",
-  "reviewed_at": "2026-08-14",
-  "upstream_commit": "c3a63b22341b439ed66cd7d3d71367abccdb0554",
+  "reviewed_at": "2026-08-17",
+  "upstream_commit": "384e11010a690c3605e9556f63732e5ea19165b7",
   "source_url": "https://raw.githubusercontent.com/webmachinelearning/webmcp/main/index.bs",
-  "sha256": "18dcbf221df37b687f62e7db1604ca2d58c9af084a6a06e1e49ffc59defd3f11",
+  "sha256": "519ee8279a891811c609c21e2c36baa6596a7e4e22d9e0133a86a3fe63a95579",
   "maximum_bytes": 2097152,
   "required_fragments": [
     "partial interface Document {",
     "readonly attribute ModelContext modelContext;",
     "Promise<undefined> registerTool(ModelContextTool tool, optional ModelContextRegisterToolOptions options = {});",
     "dictionary ModelContextRegisterToolOptions {",
-    "AbortSignal signal;"
+    "AbortSignal signal;",
+    "object inputSchema;"
   ],
   "forbidden_fragments": []
 }


### PR DESCRIPTION
Closes #80.

The weekly watcher went red on 17 August: `index.bs` moved from 56,780 to 75,306 bytes (+33%) while reporting **no missing required fragment and no forbidden fragment**. That clean bill is itself the finding — the fragment list pinned names and signatures but no field *type*, so a type change walked straight through the semantic checks.

## The three upstream commits since `c3a63b2`, reviewed

| commit | change | effect on this adapter |
|---|---|---|
| `7aa8235` | validate `exposedTo` before registering the AbortSignal algorithm | none — the adapter calls `registerTool(tool, { signal })` and never passes `exposedTo` |
| `f303c45` | spec `executeTool()`, add `ModelContextExecuteToolOptions` | none — agent-side surface on `ModelContext`; this adapter *registers against* `document.modelContext`, it does not implement the interface |
| `384e110` | `RegisteredTool#inputSchema`: `DOMString` → `object` | none, and this is the one that could have bitten |

On the third: `webmcp/src/types.ts` has always declared `inputSchema?: Record<string, unknown>` and `tools.ts` emits object literals at all five call sites. Upstream converged on the shape the adapter already used.

## IDL delta

```diff
 interface ModelContext : EventTarget {
   Promise<undefined> registerTool(ModelContextTool tool, optional ModelContextRegisterToolOptions options = {});
   Promise<sequence<RegisteredTool>> getTools(optional ModelContextGetToolOptions options = {});
+  Promise<DOMString> executeTool(RegisteredTool tool, DOMString inputArguments, optional ModelContextExecuteToolOptions options = {});
 };
+dictionary ModelContextExecuteToolOptions {
+  AbortSignal signal;
+};
 dictionary RegisteredTool {
-  DOMString inputSchema;
+  object inputSchema;
 };
```

## Changes

- `upstream_commit` → `384e110`, `sha256` → `519ee827…`, `reviewed_at` → 2026-08-17 (both hashes reproduced locally against the pinned and current sources).
- **`object inputSchema;` added to `required_fragments`** so a revert to `DOMString` fails the watcher instead of passing it.
- `webmcp/README.md` review date.

## Verification

`python3 scripts/check_webmcp_upstream.py` → `"status": "matched"`, exit 0. 164 WebMCP tests pass, `tsc --noEmit` clean, `scripts/validate_repo.py` passes.