### PR TITLE
test(revocation): stop unit tests dialling out when an SSRF guard is bypassed

### DIFF
--- a/python/tests/vcp/test_revocation.py
+++ b/python/tests/vcp/test_revocation.py
@@ -11,6 +11,7 @@ import json
 import socket
 import ssl
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -41,6 +42,28 @@ def _conformance_fixture(name: str) -> Path:
         if candidate.is_file():
             return candidate
     raise FileNotFoundError(f"Could not locate conformance/security/{name}")
+
+
+@pytest.fixture(autouse=True)
+def blocked_connection_factory() -> Iterator[MagicMock]:
+    """Default-deny the connection factory so no test can dial out.
+
+    ``_fetch_json`` only reaches the factory once its SSRF guards have passed,
+    so a test that gets there without patching the factory is about to open a
+    real socket. That does not fail -- it hangs for the full connect timeout
+    per resolved address, which is how a mutant that neuters the private-IP
+    guard was reported as a mutation-testing timeout rather than as killed.
+    Tests that exercise the transport patch this name themselves, which
+    overrides this fixture for the duration of their own patch.
+    """
+    with patch(
+        "vcp.revocation._PinnedHTTPSConnection",
+        side_effect=AssertionError(
+            "test attempted a real network connection; patch "
+            "vcp.revocation._PinnedHTTPSConnection to exercise the transport"
+        ),
+    ) as factory:
+        yield factory
 
 
 # ---------------------------------------------------------------------------
@@ -357,13 +380,17 @@ class TestPinnedHttpsTransport:
     )
     @patch("vcp.revocation.validate_uri", return_value=(True, "OK"))
     def test_fetch_rejects_empty_or_mixed_safety_resolution(
-        self, mock_validate: MagicMock, addresses: list[tuple[Any, ...]]
+        self,
+        mock_validate: MagicMock,
+        addresses: list[tuple[Any, ...]],
+        blocked_connection_factory: MagicMock,
     ) -> None:
         with (
             patch("vcp.revocation.socket.getaddrinfo", return_value=addresses),
             pytest.raises(RevocationError, match="unsafe address"),
         ):
             _fetch_json("https://status.example/check")
+        blocked_connection_factory.assert_not_called()
 
     @patch("vcp.revocation.validate_uri", return_value=(True, "OK"))
     def test_fetch_uses_sorted_pinned_addresses_and_exact_request_contract(


### PR DESCRIPTION
Fixes the scheduled **Selective mutation testing** failure on `main` ([run 32336657638](https://github.com/Creed-Space/VCP-SDK/actions/runs/32336657638)). The other three lanes passed; `Mutation (revocation)` failed with:

```
vcp.revocation*: score 65.87%/63.00%, selected 751, killed 494, survived 256
FAIL: 1 selected mutants have status timeout
```

The score was never the problem — `check_mutation_results.py` fails on infrastructure gaps, and a mutant that times out instead of dying is one.

## The timing-out mutant

`vcp.revocation.x__fetch_json__mutmut_32` flips the DNS safety guard:

```diff
-    if not addresses or any(_is_private_ip(address) for address in addresses):
+    if not addresses and any(_is_private_ip(address) for address in addresses):
```

With `and`, any non-empty resolution short-circuits and the guard never fires, so `_fetch_json` walks past SSRF protection and opens a real socket to the address under test. `test_fetch_rejects_empty_or_mixed_safety_resolution` feeds it `10.0.0.1`, `93.184.216.34` and `127.0.0.1` — so the mutant didn't fail, it *hung* for the connect timeout per address.

Measured on this tree:

| | wall time for that test |
|---|---|
| unmutated | 0.02 s |
| mutant 32, before this change | **30.21 s** |
| mutant 32, after this change | 0.36 s (fails cleanly) |

## The fix

The defect is in the test, not the guard: a unit test should never be one bad branch away from real network I/O. `_PinnedHTTPSConnection` is now default-denied by an autouse fixture — reaching the transport without opting in raises immediately. Tests that legitimately exercise the transport already patch that name, and their patch overrides the fixture for its duration, so they're unaffected.

The guard test now also asserts the factory was never called, which is the property it was actually trying to prove.

This generalises: any future mutant that neuters an SSRF guard now dies as a fast assertion rather than as a timeout.

## Verification

Ran the exact CI command against this tree (mutmut 3.7.0, same 751 selected mutants as the failing run):

```
before: selected 751, killed 494, survived 256, timeout 1   -> FAIL
after:  selected 751, killed 495, survived 256, timeout 0   -> pass
        score 65.91% / 63.00% floor, failures: []
```

Also: `tests/vcp/test_revocation.py` 104 passed in 0.26 s; `ruff check src tests` and `ruff format --check` clean.

Note that the mutation workflow is `schedule`/`workflow_dispatch` only, so it will not run on this PR — the numbers above are from running the lane locally. Worth a `workflow_dispatch` after merge to confirm on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)